### PR TITLE
release 0.7.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.7.0
 -------------
 
-Unreleased
+Released 2022-05-14
 
 - ``FileSystemCache`` now stores universal expiration timestamps using python's ``struct`` module.
 - Drop support for Python 3.6

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     "RedisCache",
     "UWSGICache",
 ]
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
Our 0.7.0 release 🎉 

**Change summary**

- ``FileSystemCache`` now stores universal expiration timestamps using python's ``struct`` module.
- Drop support for Python 3.6
