### PR TITLE
remove unused data type check in default redis serializer

### DIFF
--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -83,8 +83,6 @@ class RedisSerializer(BaseSerializer):
         """Dumps an object into a string for redis. By default it serializes
         integers as regular string and pickle dumps everything else.
         """
-        if isinstance(type(value), int):
-            return str(value).encode("ascii")
         return b"!" + pickle.dumps(value, protocol)
 
     def loads(self, value: _t.Optional[bytes]) -> _t.Any:


### PR DESCRIPTION
As said in #73, `inc` and `dec` operations are not being used at the redis layer so it seems like unnecessary complexity to treat integer data types differently from others.