### PR TITLE
Fix redis cache add without timeout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 0.9.0
+-------------
+
+Unreleased
+
+- Fix bug where cache entries would expire immediately when ``RedisCache.add``
+  was called without timeout. :pr:`157`
+
+
 Version 0.8.0
 -------------
 


### PR DESCRIPTION
fix for #156 

- [x] handle case when no timeout is passed in `RedisCache.add`
- [x] add changelog