### PR TITLE
Support for Windows when creating FileSystemCache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 
 - Fix bug where cache entries would expire immediately when ``RedisCache.add``
   was called without timeout. :pr:`157`
+- Improve `FileSystemCache.set` compatibility with Windows systems. :pr:`158`
 
 
 Version 0.8.0


### PR DESCRIPTION
This has originally been proposed as fix in flask-caching. See [the original issue](https://github.com/pallets-eco/flask-caching/issues/309) for more details.

- [x] use correct default mode based on user platform, preventing access denied errors on windows.