### PR TITLE
Improve RedisCache compatibility with flask-caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 0.9.0
 
 Unreleased
 
+- Add separate read/write clients to ``RedisCache`` to improve compatibility with flask-caching. :pr:`159`
 - Fix bug where cache entries would expire immediately when ``RedisCache.add``
   was called without timeout. :pr:`157`
 - Improve `FileSystemCache.set` compatibility with Windows systems. :pr:`158`

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -15,7 +15,7 @@ def create_cache_list(request, tmpdir):
     mc = MemcachedCache()
     mc._client.flush_all()
     rc = RedisCache(port=6360)
-    rc._client.flushdb()
+    rc._write_client.flushdb()
     request.cls.cache_list = [FileSystemCache(tmpdir), mc, rc, SimpleCache()]
 
 

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -32,7 +32,7 @@ class CustomCache(RedisCache):
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
         rc = request.param(*args, port=6360, **kwargs)
-        rc._client.flushdb()
+        rc._write_client.flushdb()
         return rc
 
     request.cls.cache_factory = _factory


### PR DESCRIPTION
Following https://github.com/pallets-eco/flask-caching/issues/362, as it is, `cachelib.RedisCache` internally uses a single client for reading&writing, making it harder to use with subclasses with separate read and write clients such as [flask_caching.backends.rediscache.RedisSentinelCache](https://github.com/pallets-eco/flask-caching/blob/master/src/flask_caching/backends/rediscache.py#L121).

- [x] update `RedisCache` so read and write operations use _read_client and _write_client, receptively, making it possible to override these from sub-classes.
- [x] add changelog
- [x] update tests