### PR TITLE
Improve error message for non str keys in FileSystemCache._get_filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 0.10.0
+-------------
+
+Unreleased
+
+- Improve error message when ``FileSystemCache`` methods are called with non-str keys.
+
+
 Version 0.9.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,9 @@
 Version 0.10.0
--------------
+--------------
 
 Unreleased
 
-- Improve error message when ``FileSystemCache`` methods are called with non-str keys.
+- Improve error message when ``FileSystemCache`` methods are called with non-str keys. :pr:`170`
 
 
 Version 0.9.0

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -199,6 +199,8 @@ class FileSystemCache(BaseCache):
         if isinstance(key, str):
             bkey = key.encode("utf-8")  # XXX unicode review
             bkey_hash = self._hash_method(bkey).hexdigest()
+        else:
+            raise TypeError(f"Key must be a string, received type {type(key)}")
         return os.path.join(self._path, bkey_hash)
 
     def get(self, key: str) -> _t.Any:


### PR DESCRIPTION
fix #169 

- [x] add changelog entry
- [x] handle non-str strings in `FileSystemCache._get_filename`