### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.10.0
 --------------
 
-Unreleased
+Released 2023-01-09
 
 - Improve error message when ``FileSystemCache`` methods are called with non-str keys. :pr:`170`
 - Added ``DynamoDb`` as a cache backend :pr:`209`

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "UWSGICache",
     "DynamoDbCache",
 ]
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
Our 0.10.0 release 🎉 

**Change summary**

- Improve error message when ``FileSystemCache`` methods are called with non-str keys. :pr:`170`
- Added ``DynamoDb`` as a cache backend :pr:`209`