### PR TITLE
Explicit stacklevel keywork in warn call

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,8 @@ def pytest_sessionfinish(session, exitstatus):
             warnings.warn(
                 "Pytest could not find tox 'TMPDIR' in the environment,"
                 " make sure the variable is set in the project tox.ini"
-                " file if you are running under tox."
+                " file if you are running under tox.",
+                stacklevel=2,
             )
         else:
             with open(script_path, mode="w") as f:


### PR DESCRIPTION
Fixes

> tests/conftest.py:25:13: B028 No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user

from pre-commit hooks