### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 0.11.0
+--------------
+
+Released 2024-02010
+
+- Drop python 3.7 support
+- Add python 3.11 support
+
+
 Version 0.10.2
 --------------
 
@@ -9,7 +18,7 @@ Released 2023-01-31
 Version 0.10.1
 --------------
 
-Unreleased
+Released 2023-01-22
 
 - Fix logging pollution due to ``DynamoDB`` logging handler
 

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
     "UWSGICache",
     "DynamoDbCache",
 ]
-__version__ = "0.10.2"
+__version__ = "0.11.0"


### PR DESCRIPTION
A bit of house keeping before getting into https://github.com/pallets-eco/cachelib/pull/332 and https://github.com/pallets-eco/cachelib/pull/214 for next release

- [x] drop py37
- [x] add py311 support