### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.13.0
 --------------
 
-Unreleased
+Released 2024-04-13
 
 -   default ``hashlib.md5`` may not be available in FIPS builds. We
     now do not access it at import time on ``FileSystemCache``so developers

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     "DynamoDbCache",
     "MongoDbCache",
 ]
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -40,6 +40,8 @@ class FileSystemCache(BaseCache):
     :param mode: the file mode wanted for the cache files, default 0600
     :param hash_method: Default hashlib.md5. The hash method used to
                         generate the filename for cached results.
+                        Default is lazy loaded and can be overriden by
+                        seeting  `_default_hash_method`
     """
 
     #: used for temporary files by the FileSystemCache


### PR DESCRIPTION
Our 0.13.0 release

**changes**

default ``hashlib.md5`` may not be available in FIPS builds. We now do not access it at import time on ``FileSystemCache``so developers have time to change the default.``hashlib.md5`` will be lazy loaded when a new default is not provided