### PR TITLE
Added index to mongodb expiration field, Fixed test cases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,19 +3,19 @@ on:
   push:
     branches:
       - main
-      - '*.x'
+      - "*.x"
     paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.rst'
+      - "docs/**"
+      - "*.md"
+      - "*.rst"
   pull_request:
     branches:
       - main
-      - '*.x'
+      - "*.x"
     paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.rst'
+      - "docs/**"
+      - "*.md"
+      - "*.rst"
 jobs:
   tests:
     name: ${{ matrix.name }}
@@ -24,28 +24,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: Linux, python: '3.11', os: ubuntu-latest, tox: py311}
-          - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
-          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
-          - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
-          - {name: Typing, python: '3.12', os: ubuntu-latest, tox: typing}
+          - { name: Linux, python: "3.11", os: ubuntu-latest, tox: py311 }
+          - { name: "3.8", python: "3.8", os: ubuntu-latest, tox: py38 }
+          - { name: "3.9", python: "3.9", os: ubuntu-latest, tox: py39 }
+          - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
+          - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
+          - { name: Typing, python: "3.12", os: ubuntu-latest, tox: typing }
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: install external dependencies Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install libmemcached-dev memcached redis-server
+      - name: Setup Memcached
+        uses: niden/actions-memcached@v7
+      - name: Setup Redis
+        uses: supercharge/redis-github-action@1.7.0
+        with:
+          redis-version: latest
       - name: setup dynamodb-local
-        uses: rrainn/dynamodb-action@v2.0.1
+        uses: rrainn/dynamodb-action@v3.0.0
       - name: Start MongoDB
         uses: wbari/start-mongoDB@v0.2
         with:
-          mongoDBVersion: 'latest'
+          mongoDBVersion: "latest"
       - name: update pip
         run: |
           pip install -U wheel
@@ -53,7 +54,7 @@ jobs:
           python -m pip install -U pip
       - name: get pip cache dir
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: cache pip
         uses: actions/cache@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,7 @@ jobs:
           - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
           - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
           - { name: Typing, python: "3.12", os: ubuntu-latest, tox: typing }
+          - { name: "3.13", python: "3.13", os: ubuntu-latest, tox: py313 }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      - name: install external dependencies Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libmemcached-dev
       - name: Setup Memcached
         uses: niden/actions-memcached@v7
       - name: Setup Redis

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,13 +55,13 @@ jobs:
         id: pip-cache
         run: echo "::set-output name=dir::$(pip cache dir)"
       - name: cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - name: cache mypy
         if: matrix.tox == 'typing'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./.mypy_cache
           key: mypy|${{ matrix.python }}|${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,6 @@ jobs:
           - { name: "3.10", python: "3.10", os: ubuntu-latest, tox: py310 }
           - { name: "3.11", python: "3.11", os: ubuntu-latest, tox: py311 }
           - { name: Typing, python: "3.12", os: ubuntu-latest, tox: typing }
-          - { name: "3.13", python: "3.13", os: ubuntu-latest, tox: py313 }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 0.13.1
+--------------
+
+UnReleased
+- Added an index for the expiration field in MongoDbCache to improve performance.
+- Modified the _utcnow method to use datetime.UTC if available.
+- Fixed broken test cases. Updated the syntax for branch and path patterns, upgraded action versions, and modified job steps to use new actions for setting up Memcached and Redis
+
+
 Version 0.13.0
 --------------
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -44,5 +44,5 @@ six==1.16.0
     # via python-dateutil
 urllib3
     # via botocore
-uwsgi==2.0.24
+uwsgi==2.0.28
     # via -r requirements/tests.in

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     "DynamoDbCache",
     "MongoDbCache",
 ]
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -90,7 +90,7 @@ class DynamoDbCache(BaseCache):
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        return datetime.datetime.now(datetime.UTC).replace(tzinfo=datetime.timezone.utc)
 
     def _get_item(self, key: str, attributes: _t.Optional[list] = None) -> _t.Any:
         """

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -90,7 +90,11 @@ class DynamoDbCache(BaseCache):
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.now(datetime.UTC).replace(tzinfo=datetime.timezone.utc)
+        if hasattr(datetime, "UTC"):
+            res = datetime.datetime.now(datetime.UTC)
+        else:
+            res = datetime.datetime.utcnow()
+        return res
 
     def _get_item(self, key: str, attributes: _t.Optional[list] = None) -> _t.Any:
         """

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -48,12 +48,14 @@ class MongoDbCache(BaseCache):
         }
         if "id" not in all_keys:
             self.client.create_index("id", unique=True)
+        if "expiration" not in all_keys:
+            self.client.create_index("expiration")
         self.key_prefix = key_prefix or ""
         self.collection = collection
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        return datetime.datetime.now(datetime.UTC)
 
     def _expire_records(self) -> _t.Any:
         res = self.client.delete_many({"expiration": {"$lte": self._utcnow()}})

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -48,6 +48,8 @@ class MongoDbCache(BaseCache):
         }
         if "id" not in all_keys:
             self.client.create_index("id", unique=True)
+        if "expiration" not in all_keys:
+            self.client.create_index("expiration", expireAfterSeconds=0)
         self.key_prefix = key_prefix or ""
         self.collection = collection
 

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -55,7 +55,11 @@ class MongoDbCache(BaseCache):
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.now(datetime.UTC)
+        if hasattr(datetime, "UTC"):
+            res = datetime.datetime.now(datetime.UTC)
+        else:
+            res = datetime.datetime.utcnow()
+        return res
 
     def _expire_records(self) -> _t.Any:
         res = self.client.delete_many({"expiration": {"$lte": self._utcnow()}})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import warnings
 from pathlib import Path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import warnings
 from pathlib import Path
 
 import pytest
-from xprocess import ProcessStarter
 
 
 def under_uwsgi():
@@ -31,48 +30,6 @@ def pytest_sessionfinish(session, exitstatus):
         else:
             with open(script_path, mode="w") as f:
                 f.write(f"import sys; sys.exit({exitstatus})")
-
-
-@pytest.fixture(scope="class")
-def redis_server(xprocess):
-    package_name = "redis"
-    pytest.importorskip(
-        modname=package_name, reason=f"could not find python package {package_name}"
-    )
-
-    class Starter(ProcessStarter):
-        pattern = "[Rr]eady to accept connections"
-        args = ["redis-server", "--port 6360"]
-
-        def startup_check(self):
-            out = subprocess.run(
-                ["redis-cli", "-p", "6360", "ping"], stdout=subprocess.PIPE
-            )
-            return out.stdout == b"PONG\n"
-
-    xprocess.ensure(package_name, Starter)
-    yield
-    xprocess.getinfo(package_name).terminate()
-
-
-@pytest.fixture(scope="class")
-def memcached_server(xprocess):
-    package_name = "pylibmc"
-    pytest.importorskip(
-        modname=package_name, reason=f"could not find python package {package_name}"
-    )
-
-    class Starter(ProcessStarter):
-        pattern = "server listening"
-        args = ["memcached", "-vv"]
-
-        def startup_check(self):
-            out = subprocess.run(["memcached"], stderr=subprocess.PIPE)
-            return b"Address already" in out.stderr
-
-    xprocess.ensure(package_name, Starter)
-    yield
-    xprocess.getinfo(package_name).terminate()
 
 
 class TestData:

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -14,7 +14,7 @@ from cachelib import SimpleCache
 def create_cache_list(request, tmpdir):
     mc = MemcachedCache()
     mc._client.flush_all()
-    rc = RedisCache(port=6360)
+    rc = RedisCache()
     rc._write_client.flushdb()
     request.cls.cache_list = [FileSystemCache(tmpdir), mc, rc, SimpleCache()]
 

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -19,7 +19,6 @@ def create_cache_list(request, tmpdir):
     request.cls.cache_list = [FileSystemCache(tmpdir), mc, rc, SimpleCache()]
 
 
-@pytest.mark.usefixtures("redis_server", "memcached_server")
 class TestInterfaceUniformity:
     def test_types_have_all_base_methods(self):
         public_api_methods = [

--- a/tests/test_memcached_cache.py
+++ b/tests/test_memcached_cache.py
@@ -16,6 +16,5 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
-@pytest.mark.usefixtures("memcached_server")
 class TestMemcachedCache(CommonTests, ClearTests, HasTests):
     pass

--- a/tests/test_mongodb_cache.py
+++ b/tests/test_mongodb_cache.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from clear import ClearTests
 from common import CommonTests
@@ -27,4 +29,17 @@ def cache_factory(request):
 
 
 class TestMongoDbCache(CommonTests, ClearTests, HasTests):
-    pass
+    def test_auto_expire(self):
+        """Test that MongoDB's TTL index automatically expires cache entries."""
+        cache = self.cache_factory()
+        # Set a cache entry with a short timeout
+        cache.set("auto_expire_key", "value", timeout=2)
+
+        # Verify it exists
+        assert cache.get("auto_expire_key") == "value"
+
+        # Wait for expiration (add buffer time for MongoDB TTL monitor)
+        time.sleep(5)
+
+        # Verify it has expired
+        assert cache.get("auto_expire_key") is None

--- a/tests/test_mongodb_cache.py
+++ b/tests/test_mongodb_cache.py
@@ -19,6 +19,7 @@ def cache_factory(request):
             subkey[0] for value in index_info.values() for subkey in value["key"]
         }
         assert "id" in all_keys, "Failed to create index on 'id' field"
+        assert "expiration" in all_keys, "Failed to create index on 'expiration' field"
         rc.clear()
         return rc
 

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -31,7 +31,7 @@ class CustomCache(RedisCache):
 @pytest.fixture(autouse=True, params=[RedisCache, CustomCache])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
-        rc = request.param(*args, port=6360, **kwargs)
+        rc = request.param(*args, **kwargs)
         rc._write_client.flushdb()
         return rc
 

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -42,7 +42,6 @@ def my_callable_key() -> str:
     return "bacon"
 
 
-@pytest.mark.usefixtures("redis_server")
 class TestRedisCache(CommonTests, ClearTests, HasTests):
     def test_callable_key(self):
         cache = self.cache_factory()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}
+    py{38,39,310,311,312,313}
     style
     typing
     docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313}
+    py{38,39,310,311,312}
     style
     typing
     docs


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/tests.yaml` file, enhancements to the `MongoDbCache` and `DynamoDbCache` classes, and improvements to test cases. The most important changes include updating action versions and job steps in the GitHub workflows, adding an index for the expiration field in `MongoDbCache`, modifying the `_utcnow` method, and updating test configurations.

### GitHub Workflows:
* Updated branch and path patterns to use double quotes instead of single quotes in `.github/workflows/tests.yaml`.
* Upgraded action versions and modified job steps to use new actions for setting up Memcached and Redis in `.github/workflows/tests.yaml`.

### Cache Enhancements:
* Added an auto expire index for the expiration field in `MongoDbCache` to improve performance in `src/cachelib/mongodb.py`.
* Modified the `_utcnow` method to use `datetime.UTC` if available in `src/cachelib/dynamodb.py` and `src/cachelib/mongodb.py`. [[1]](diffhunk://#diff-d5fd0709b6ea1c0b6b5508ddb802e041894ccc322b6333aaf431ebacb98def24L93-R97) [[2]](diffhunk://#diff-7c077a456a63f9bad63971cf05befc3f4de385fb02d9922be09c1f27aa6fe3e6R51-R62)

### Test Improvements:
* Removed the `redis_server` and `memcached_server` fixtures and updated test cases to use default ports and setups in `tests/conftest.py`, `tests/test_interface_uniformity.py`, `tests/test_memcached_cache.py`, and `tests/test_redis_cache.py`. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L2-L7) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L36-L77) [[3]](diffhunk://#diff-266b80d17867f9fbb9ec96e310bb25b918a28dea549e48f62be6422477a44d7eL17-L22) [[4]](diffhunk://#diff-f4a70c9210e9e7c651de0d17f222625d099d774b15eddf76d914d5f44ffa4ac7L19) [[5]](diffhunk://#diff-84eab112a80d398c1755eb680db31aebafc18b7cc03c5ae9862f99c0a058de98L34-R34) [[6]](diffhunk://#diff-84eab112a80d398c1755eb680db31aebafc18b7cc03c5ae9862f99c0a058de98L45)
* Added a test for auto-expiration of cache entries in `tests/test_mongodb_cache.py`.

### Version Updates:
* Updated the version to `0.13.1` in `CHANGES.rst` and `src/cachelib/__init__.py`. [[1]](diffhunk://#diff-ff3c479edefad986d2fe6fe7ead575a46b086e3bbcf0ccc86d85efc4a4c63c79R1-R9) [[2]](diffhunk://#diff-78293d54d043773a8387e711a2c281a9e0acbe88258af5a81743136ae5ed9083L22-R22)
* Upgraded `uwsgi` from `2.0.24` to `2.0.28` in `requirements/tests.txt`.
* Added Python 3.12 to the `tox` environments in `tox.ini`.

### Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.