### PR TITLE
fix: failing CI `datetime.utcnow()` Deprecation warnings and `memcache` starting twice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
     "default::pytest.PytestUnraisableExceptionWarning",
     "default::DeprecationWarning:cachelib.uwsgi",
     "default::DeprecationWarning:cachelib.redis",
+    "default::DeprecationWarning:botocore",
 ]
 
 [tool.coverage.run]

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -90,7 +90,7 @@ class DynamoDbCache(BaseCache):
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     def _get_item(
         self, key: str, attributes: _t.Optional[_t.List[_t.Any]] = None

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -53,7 +53,7 @@ class MongoDbCache(BaseCache):
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     def _expire_records(self) -> _t.Any:
         res = self.client.delete_many({"expiration": {"$lte": self._utcnow()}})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,10 +64,10 @@ def memcached_server(xprocess):
 
     class Starter(ProcessStarter):
         pattern = "server listening"
-        args = ["memcached", "-vv"]
+        args = ["memcached", "-vv", "-p", "11212"]
 
         def startup_check(self):
-            out = subprocess.run(["memcached"], stderr=subprocess.PIPE)
+            out = subprocess.run(["memcached", "-p", "11212"], stderr=subprocess.PIPE)
             return b"Address already" in out.stderr
 
     xprocess.ensure(package_name, Starter)

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -12,7 +12,7 @@ from cachelib import SimpleCache
 
 @pytest.fixture(autouse=True)
 def create_cache_list(request, tmpdir):
-    mc = MemcachedCache()
+    mc = MemcachedCache(servers=["127.0.0.1:11212"])
     mc._client.flush_all()
     rc = RedisCache(port=6360)
     rc._write_client.flushdb()

--- a/tests/test_memcached_cache.py
+++ b/tests/test_memcached_cache.py
@@ -9,6 +9,7 @@ from cachelib import MemcachedCache
 @pytest.fixture(autouse=True)
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
+        kwargs.setdefault("servers", ["127.0.0.1:11212"])
         mc = MemcachedCache(*args, **kwargs)
         mc._client.flush_all()
         return mc


### PR DESCRIPTION
This pull requests fixes the failing CI errors in #420  by replacing `datetime.utcnow()` with `datetime.now()` and silencing warning from `botocore` related to it and starting `memcache` on a different port since it automatically starts when it's installed.