### PR TITLE
feat: add network marker to tests requiring network access

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,14 @@ python_requires = >= 3.8
 where = src
 
 [tool:pytest]
+addopts = --strict-markers
 testpaths = tests
 filterwarnings =
     error
     default::DeprecationWarning:cachelib.uwsgi
     default::DeprecationWarning:cachelib.redis
+markers =
+    network: mark a test which requires net access
 
 [coverage:run]
 branch = True

--- a/tests/test_dynamodb_cache.py
+++ b/tests/test_dynamodb_cache.py
@@ -29,5 +29,6 @@ def cache_factory(request):
         request.cls.cache_factory = _factory
 
 
+@pytest.mark.network
 class TestDynamoDbCache(CommonTests, ClearTests, HasTests):
     pass

--- a/tests/test_interface_uniformity.py
+++ b/tests/test_interface_uniformity.py
@@ -19,6 +19,7 @@ def create_cache_list(request, tmpdir):
     request.cls.cache_list = [FileSystemCache(tmpdir), mc, rc, SimpleCache()]
 
 
+@pytest.mark.network
 @pytest.mark.usefixtures("redis_server", "memcached_server")
 class TestInterfaceUniformity:
     def test_types_have_all_base_methods(self):

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -42,6 +42,7 @@ def my_callable_key() -> str:
     return "bacon"
 
 
+@pytest.mark.network
 @pytest.mark.usefixtures("redis_server")
 class TestRedisCache(CommonTests, ClearTests, HasTests):
     def test_callable_key(self):


### PR DESCRIPTION
## What changed

Add pytest network marker to tests that require network access:

1. Add --strict-markers to pytest configuration in setup.cfg
2. Define 'network' marker for tests requiring network
3. Mark DynamoDB tests as network tests
4. Mark Redis tests as network tests
5. Mark interface uniformity tests as network tests

## Why

When building packages on systems without network access (like SUSE build servers), tests that require network connections fail. This change allows skipping network tests with:

```bash
pytest -k 'not network'
```

This makes it easier to run tests in environments where network is not available.

## How it was tested

- Verified all network-dependent tests are properly marked
- Verified the marker is defined in setup.cfg
- Verified --strict-markers is enabled to catch undefined markers