### PR TITLE
fix: delete many in redis and memcache and add tests for it

### DIFF
--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -136,11 +136,13 @@ class MemcachedCache(BaseCache):
 
     def delete_many(self, *keys: str) -> _t.List[_t.Any]:
         new_keys = []
+        normalized_keys = []
         for key in keys:
-            key = self._normalize_key(key)
-            if _test_memcached_key(key):
+            normalized = self._normalize_key(key)
+            if _test_memcached_key(normalized):
                 new_keys.append(key)
-        self._client.delete_multi(new_keys)
+                normalized_keys.append(normalized)
+        self._client.delete_multi(normalized_keys)
         return [k for k in new_keys if not self.has(k)]
 
     def has(self, key: str) -> bool:

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -135,14 +135,14 @@ class MemcachedCache(BaseCache):
         return False
 
     def delete_many(self, *keys: str) -> _t.List[_t.Any]:
-        new_keys = set()
-        normalized_keys = set()
+        new_keys = []
+        normalized_keys = []
         for key in keys:
             normalized = self._normalize_key(key)
             if _test_memcached_key(normalized):
-                new_keys.add(key)
-                normalized_keys.add(normalized)
-        self._client.delete_multi(list(normalized_keys))
+                new_keys.append(key)
+                normalized_keys.append(normalized)
+        self._client.delete_multi(normalized_keys)
         return [k for k in new_keys if not self.has(k)]
 
     def has(self, key: str) -> bool:

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -135,14 +135,14 @@ class MemcachedCache(BaseCache):
         return False
 
     def delete_many(self, *keys: str) -> _t.List[_t.Any]:
-        new_keys = []
-        normalized_keys = []
+        new_keys = set()
+        normalized_keys = set()
         for key in keys:
             normalized = self._normalize_key(key)
             if _test_memcached_key(normalized):
-                new_keys.append(key)
-                normalized_keys.append(normalized)
-        self._client.delete_multi(normalized_keys)
+                new_keys.add(key)
+                normalized_keys.add(normalized)
+        self._client.delete_multi(list(normalized_keys))
         return [k for k in new_keys if not self.has(k)]
 
     def has(self, key: str) -> bool:

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -137,7 +137,7 @@ class RedisCache(BaseCache):
         else:
             prefixed_keys = [k for k in keys]
         self._write_client.delete(*prefixed_keys)
-        return [k for k in prefixed_keys if not self.has(k)]
+        return [k for k in keys if not self.has(k)]
 
     def has(self, key: str) -> bool:
         return bool(self._read_client.exists(f"{self._get_prefix()}{key}"))

--- a/tests/delete_many_with_prefix.py
+++ b/tests/delete_many_with_prefix.py
@@ -1,0 +1,12 @@
+from conftest import TestData
+
+
+class DeleteManyWithPrefixTests(TestData):
+    """Tests for the 'delete_many' method when a key prefix is used"""
+
+    def test_delete_many_with_prefix(self):
+        cache = self.cache_factory(key_prefix="test_prefix:")
+        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
+        result = cache.delete_many("foo", "bar", "baz")
+        assert result == ["foo", "bar", "baz"]
+        assert not any(cache.get_many("foo", "bar", "baz"))

--- a/tests/test_dynamodb_cache.py
+++ b/tests/test_dynamodb_cache.py
@@ -30,4 +30,9 @@ def cache_factory(request):
 
 
 class TestDynamoDbCache(CommonTests, ClearTests, HasTests):
-    pass
+    def test_delete_many_with_prefix(self):
+        cache = self.cache_factory(key_prefix="test_prefix:")
+        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
+        result = cache.delete_many("foo", "bar", "baz")
+        assert result == ["foo", "bar", "baz"]
+        assert not any(cache.get_many("foo", "bar", "baz"))

--- a/tests/test_dynamodb_cache.py
+++ b/tests/test_dynamodb_cache.py
@@ -1,6 +1,7 @@
 import pytest
 from clear import ClearTests
 from common import CommonTests
+from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
 
 from cachelib import DynamoDbCache
@@ -29,10 +30,5 @@ def cache_factory(request):
         request.cls.cache_factory = _factory
 
 
-class TestDynamoDbCache(CommonTests, ClearTests, HasTests):
-    def test_delete_many_with_prefix(self):
-        cache = self.cache_factory(key_prefix="test_prefix:")
-        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
-        result = cache.delete_many("foo", "bar", "baz")
-        assert result == ["foo", "bar", "baz"]
-        assert not any(cache.get_many("foo", "bar", "baz"))
+class TestDynamoDbCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+    pass

--- a/tests/test_memcached_cache.py
+++ b/tests/test_memcached_cache.py
@@ -19,4 +19,9 @@ def cache_factory(request):
 
 @pytest.mark.usefixtures("memcached_server")
 class TestMemcachedCache(CommonTests, ClearTests, HasTests):
-    pass
+    def test_delete_many_with_prefix(self):
+        cache = self.cache_factory(key_prefix="test_prefix:")
+        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
+        result = cache.delete_many("foo", "bar", "baz")
+        assert result == ["foo", "bar", "baz"]
+        assert not any(cache.get_many("foo", "bar", "baz"))

--- a/tests/test_memcached_cache.py
+++ b/tests/test_memcached_cache.py
@@ -1,6 +1,7 @@
 import pytest
 from clear import ClearTests
 from common import CommonTests
+from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
 
 from cachelib import MemcachedCache
@@ -18,10 +19,5 @@ def cache_factory(request):
 
 
 @pytest.mark.usefixtures("memcached_server")
-class TestMemcachedCache(CommonTests, ClearTests, HasTests):
-    def test_delete_many_with_prefix(self):
-        cache = self.cache_factory(key_prefix="test_prefix:")
-        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
-        result = cache.delete_many("foo", "bar", "baz")
-        assert result == ["foo", "bar", "baz"]
-        assert not any(cache.get_many("foo", "bar", "baz"))
+class TestMemcachedCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+    pass

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -50,3 +50,10 @@ class TestRedisCache(CommonTests, ClearTests, HasTests):
         assert cache.get(my_callable_key) == "sausages"
         assert cache.set(lambda: "spam", "sausages")
         assert cache.get(lambda: "spam") == "sausages"
+
+    def test_delete_many_with_prefix(self):
+        cache = self.cache_factory(key_prefix="test_prefix:")
+        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
+        result = cache.delete_many("foo", "bar", "baz")
+        assert result == ["foo", "bar", "baz"]
+        assert not any(cache.get_many("foo", "bar", "baz"))

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -1,6 +1,7 @@
 import pytest
 from clear import ClearTests
 from common import CommonTests
+from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
 
 from cachelib import RedisCache
@@ -43,17 +44,10 @@ def my_callable_key() -> str:
 
 
 @pytest.mark.usefixtures("redis_server")
-class TestRedisCache(CommonTests, ClearTests, HasTests):
+class TestRedisCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
     def test_callable_key(self):
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")
         assert cache.get(my_callable_key) == "sausages"
         assert cache.set(lambda: "spam", "sausages")
         assert cache.get(lambda: "spam") == "sausages"
-
-    def test_delete_many_with_prefix(self):
-        cache = self.cache_factory(key_prefix="test_prefix:")
-        cache.set_many({"foo": 1, "bar": 2, "baz": 3})
-        result = cache.delete_many("foo", "bar", "baz")
-        assert result == ["foo", "bar", "baz"]
-        assert not any(cache.get_many("foo", "bar", "baz"))


### PR DESCRIPTION
We were checking against normalized keys in the return of `delete_many` while `has` also normalizes the keys resulting in wrong comparison.
This pull request checks against non normalized keys so the comparison is correct and adds tests for the untested `delete_many`.
fixes #442 