### PR TITLE
fix: add was failing for expired keys while it should work

### DIFF
--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -80,9 +80,11 @@ class SimpleCache(BaseCache):
         expires = self._normalize_timeout(timeout)
         self._prune()
         item = (expires, self.serializer.dumps(value))
-        if key in self._cache:
+        # key exists and is not expired, do not add
+        if self.has(key):
             return False
-        self._cache.setdefault(key, item)
+        # key does not exist or is expired, add it
+        self._cache[key] = item
         return True
 
     def delete(self, key: str) -> bool:

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -60,6 +60,14 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests):
         cache = self.cache_factory(threshold=0)
         assert cache._threshold == 500
 
+    def test_add_on_expired_key_succeeds(self):
+        """add() on a key whose TTL has elapsed should succeed."""
+        cache = self.cache_factory()
+        cache.set("key", "original", timeout=0.1)
+        sleep(0.5)
+        assert cache.add("key", "new") is True
+        assert cache.get("key") == "new"
+
     def test_has_on_expired_key_returns_false(self):
         cache = self.cache_factory()
         cache.set("key", "value", timeout=0.1)


### PR DESCRIPTION
Previously we weren't checking if a key expired in `add()` function which means that expired keys were treated the same as non expired keys and skipping addition of them