### PR TITLE
release version 0.14.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Version 0.14.0
 --------------
 
-Unreleased
+Released 2026-05-09
 
 - Improve typing and refresh project to use pyproject and pallets workflows :pr:`420`
 - Replace deprecated ``datetime.utcnow()`` with ``datetime.now()`` :pr:`421`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cachelib"
-version = "0.14.0.dev"
+version = "0.14.0"
 description = "A collection of cache libraries in the same API interface."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     "MongoDbCache",
     "ValkeyCache",
 ]
-__version__ = "0.14.0.dev"
+__version__ = "0.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -255,7 +255,7 @@ wheels = [
 
 [[package]]
 name = "cachelib"
-version = "0.14.0.dev0"
+version = "0.14.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
new release v0.14.0

- Improve typing and refresh project to use pyproject and pallets workflows :pr:`420`
- Replace deprecated ``datetime.utcnow()`` with ``datetime.now()`` :pr:`421`
- Fix ``FileSystemCache`` permission errors on Network Attached Storage (NAS) when trying
  to perform operations on files that are open in other processes :pr:`424`
- Fix ``delete_many()`` in ``RedisCache`` and ``MemcachedCache`` incorrectly reporting
  failed deletions due to comparing normalized keys against non-normalized keys :pr:`443`
- Fix serializer returning an unbound variable error instead of ``None`` when a
  ``pickle`` error is raised during serialization :pr:`448`
- Fix ``add()`` in ``SimpleCache`` treating expired keys as still valid, preventing them
  from being overwritten until explicitly deleted :pr:`449`
- Add valkey backend :pr:`441`