### PR TITLE
Add optional dependency extras for cache backends

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,18 +24,28 @@ will work without any additional dependencies.
 However, some backends require additional dependencies to be installed.
 
 CacheLib will detect and use them if they are already installed but you will
-need to install them manually if you want to use the corresponding backends:
+need to install the corresponding optional dependency extra if you want to use
+one of those backends:
 
--   `redis-py <https://redis-py.readthedocs.io/>`_ for
+-   ``cachelib[redis]`` installs
+    `redis-py <https://redis-py.readthedocs.io/>`_ for
     :class:`.RedisCache`.
--   `pylibmc <https://sendapatch.se/projects/pylibmc/>`_ or
+-   ``cachelib[memcached]`` installs
+    `pylibmc <https://sendapatch.se/projects/pylibmc/>`_ for
+    :class:`.MemcachedCache`. CacheLib can also use
     `python-memcached <https://github.com/linuxfoundation/python-memcached>`_
-    for :class:`.MemcachedCache`.
--   `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_
+    if it is already installed.
+-   ``cachelib[dynamodb]`` installs
+    `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_
     for :class:`.DynamoDbCache`.
--   `pymongo <https://pymongo.readthedocs.io/>`_ for
+-   ``cachelib[mongodb]`` installs
+    `pymongo <https://pymongo.readthedocs.io/>`_ for
     :class:`.MongoDbCache`.
--   `valkey-py <https://valkey-py.readthedocs.io/en/latest/>`_ for
+-   ``cachelib[uwsgi]`` installs
+    `uWSGI <https://uwsgi-docs.readthedocs.io/>`_ for
+    :class:`.UWSGICache` on supported platforms.
+-   ``cachelib[valkey]`` installs
+    `valkey-py <https://valkey-py.readthedocs.io/en/latest/>`_ for
     :class:`.ValkeyCache`.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,27 @@ Changes = "https://cachelib.readthedocs.io/page/changes/"
 Source = "https://github.com/pallets-eco/cachelib/"
 Chat = "https://discord.gg/pallets"
 
+[project.optional-dependencies]
+dynamodb = [
+    "boto3",
+]
+memcached = [
+    "pylibmc",
+]
+mongodb = [
+    "pymongo",
+]
+redis = [
+    "redis",
+]
+uwsgi = [
+    "uwsgi==2.0.25; python_full_version < '3.10' and platform_system != 'Windows'",
+    "uwsgi; python_full_version >= '3.10' and platform_system != 'Windows'",
+]
+valkey = [
+    "valkey",
+]
+
 [dependency-groups]
 dev = [
     "ruff",

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,38 @@
+from importlib import metadata as importlib_metadata
+
+BACKEND_EXTRAS = {
+    "dynamodb": {"boto3"},
+    "memcached": {"pylibmc"},
+    "mongodb": {"pymongo"},
+    "redis": {"redis"},
+    "uwsgi": {"uwsgi"},
+    "valkey": {"valkey"},
+}
+
+
+def is_for_extra(requirement, extra):
+    return f"extra == '{extra}'" in requirement or f'extra == "{extra}"' in requirement
+
+
+def test_backend_extras_are_advertised():
+    metadata = importlib_metadata.metadata("cachelib")
+    extras = set(metadata.get_all("Provides-Extra") or [])
+
+    assert BACKEND_EXTRAS.keys() <= extras
+
+
+def test_backend_extras_install_expected_dependencies():
+    requirements = importlib_metadata.requires("cachelib") or []
+
+    for extra, expected_names in BACKEND_EXTRAS.items():
+        extra_requirements = [
+            requirement
+            for requirement in requirements
+            if is_for_extra(requirement, extra)
+        ]
+
+        for expected_name in expected_names:
+            assert any(
+                requirement.lower().startswith(expected_name)
+                for requirement in extra_requirements
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -258,6 +258,33 @@ name = "cachelib"
 version = "0.15.0.dev0"
 source = { editable = "." }
 
+[package.optional-dependencies]
+dynamodb = [
+    { name = "boto3", version = "1.37.38", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "boto3", version = "1.40.65", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "boto3", version = "1.43.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+memcached = [
+    { name = "pylibmc" },
+]
+mongodb = [
+    { name = "pymongo", version = "4.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pymongo", version = "4.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+redis = [
+    { name = "redis", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "redis", version = "7.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+uwsgi = [
+    { name = "uwsgi", version = "2.0.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'win32'" },
+    { name = "uwsgi", version = "2.0.31", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'win32'" },
+]
+valkey = [
+    { name = "valkey", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "valkey", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
@@ -322,6 +349,16 @@ typing = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "boto3", marker = "extra == 'dynamodb'" },
+    { name = "pylibmc", marker = "extra == 'memcached'" },
+    { name = "pymongo", marker = "extra == 'mongodb'" },
+    { name = "redis", marker = "extra == 'redis'" },
+    { name = "uwsgi", marker = "python_full_version >= '3.10' and sys_platform != 'win32' and extra == 'uwsgi'" },
+    { name = "uwsgi", marker = "python_full_version < '3.10' and sys_platform != 'win32' and extra == 'uwsgi'", specifier = "==2.0.25" },
+    { name = "valkey", marker = "extra == 'valkey'" },
+]
+provides-extras = ["dynamodb", "memcached", "mongodb", "redis", "uwsgi", "valkey"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Added optional dependency extras for Redis, Memcached, DynamoDB, MongoDB, uWSGI, and Valkey backends.
- Updated `uv.lock` so locked installs know about the new extras metadata.
- Updated installation docs to show backend-specific `cachelib[...]` installs.
- Added metadata tests that verify the advertised extras and their dependencies.

## Tests
- `wsl sh -lc "~/.venvs/cachelib-uv/bin/uv lock --check"`
- `.\.venv-verify\Scripts\python -m pytest tests\test_optional_dependencies.py -q` (`2 passed`)
- `.\.venv-verify\Scripts\python -m pytest tests\test_simple_cache.py tests\test_file_system_cache.py -q` (`130 passed`)
- `.\.venv-verify\Scripts\python -m ruff check tests\test_optional_dependencies.py` (`All checks passed!`)
- `.\.venv-verify\Scripts\python -m ruff format --check tests\test_optional_dependencies.py` (`1 file already formatted`)
- `uv run --locked --no-default-groups --group docs sphinx-build -E -W -b dirhtml docs docs/_build/dirhtml` (`build succeeded`)