### PR TITLE
Make `SimpleCache` backend thread-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.15.0
 
 Unreleased
 
+- Add ``ThreadedSimpleCache``, a thread-safe variant of ``SimpleCache`` backed
+  by a reentrant ``threading.RLock``. :issue:`446`
 
 Version 0.14.0
 --------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,7 @@ Version 0.15.0
 
 Unreleased
 
-- Add ``ThreadedSimpleCache``, a thread-safe variant of ``SimpleCache`` backed
-  by a reentrant ``threading.RLock``. :issue:`446`
+- Make ``SimpleCache`` thread-safe using a ``threading.RLock``. :issue:`446`
 
 Version 0.14.0
 --------------

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -6,7 +6,6 @@ from cachelib.memcached import MemcachedCache
 from cachelib.mongodb import MongoDbCache
 from cachelib.redis import RedisCache
 from cachelib.simple import SimpleCache
-from cachelib.simple import ThreadedSimpleCache
 from cachelib.uwsgi import UWSGICache
 from cachelib.valkey import ValkeyCache
 
@@ -14,7 +13,6 @@ __all__ = [
     "BaseCache",
     "NullCache",
     "SimpleCache",
-    "ThreadedSimpleCache",
     "FileSystemCache",
     "MemcachedCache",
     "RedisCache",

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -6,6 +6,7 @@ from cachelib.memcached import MemcachedCache
 from cachelib.mongodb import MongoDbCache
 from cachelib.redis import RedisCache
 from cachelib.simple import SimpleCache
+from cachelib.simple import ThreadedSimpleCache
 from cachelib.uwsgi import UWSGICache
 from cachelib.valkey import ValkeyCache
 
@@ -13,6 +14,7 @@ __all__ = [
     "BaseCache",
     "NullCache",
     "SimpleCache",
+    "ThreadedSimpleCache",
     "FileSystemCache",
     "MemcachedCache",
     "RedisCache",

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -7,10 +7,9 @@ from cachelib.serializers import SimpleSerializer
 
 
 class SimpleCache(BaseCache):
-    """Simple memory cache for single process environments.  This class exists
-    mainly for the development server and is not 100% thread safe.  It tries
-    to use as many atomic operations as possible and no locks for simplicity
-    but it could happen under heavy load that keys are added multiple times.
+    """Simple memory cache for single process environments. All operations
+    are protected by a :class:`threading.RLock`, making this cache safe
+    to use in multi-threaded applications.
 
     :param threshold: the maximum number of items the cache stores before
                       it starts deleting some.
@@ -29,6 +28,7 @@ class SimpleCache(BaseCache):
         BaseCache.__init__(self, default_timeout)
         self._cache: _t.Dict[str, _t.Any] = {}
         self._threshold = threshold or 500  # threshold = 0
+        self._lock = threading.RLock()
 
     def _over_threshold(self) -> bool:
         return len(self._cache) > self._threshold
@@ -62,106 +62,51 @@ class SimpleCache(BaseCache):
         return timeout
 
     def get(self, key: str) -> _t.Any:
-        try:
-            expires, value = self._cache[key]
-            if expires == 0 or expires > time():
-                return self.serializer.loads(value)
-        except KeyError:
-            return None
-
-    def set(
-        self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
-    ) -> _t.Optional[bool]:
-        expires = self._normalize_timeout(timeout)
-        self._prune()
-        self._cache[key] = (expires, self.serializer.dumps(value))
-        return True
-
-    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
-        expires = self._normalize_timeout(timeout)
-        self._prune()
-        item = (expires, self.serializer.dumps(value))
-        # key exists and is not expired, do not add
-        if self.has(key):
-            return False
-        # key does not exist or is expired, add it
-        self._cache[key] = item
-        return True
-
-    def delete(self, key: str) -> bool:
-        return self._cache.pop(key, None) is not None
-
-    def has(self, key: str) -> bool:
-        try:
-            expires, value = self._cache[key]
-            return bool(expires == 0 or expires > time())
-        except KeyError:
-            return False
-
-    def clear(self) -> bool:
-        self._cache.clear()
-        return not bool(self._cache)
-
-
-class ThreadedSimpleCache(SimpleCache):
-    """A thread-safe variant of :class:`SimpleCache`.
-
-    All single-key operations (``get``, ``set``, ``add``, ``delete``, ``has``,
-    ``inc``, ``dec``, ``clear``) are protected by a reentrant lock
-    (``threading.RLock``), making this backend safe to share between
-    threads. A reentrant lock is required because ``inc`` and ``dec`` call
-    ``get`` and ``set`` internally, which would otherwise deadlock.
-
-    The batch helpers inherited from :class:`BaseCache` (``get_many``,
-    ``set_many``, ``delete_many``, ``get_dict``) acquire the lock for each
-    underlying single-key call but are **not** atomic across the whole
-    batch. Use single-key operations if you need an all-or-nothing
-    guarantee across multiple keys.
-
-    The API is otherwise identical to :class:`SimpleCache`. Use this
-    backend whenever your application serves requests from multiple
-    threads concurrently.
-
-    :param threshold: the maximum number of items the cache stores before
-                      it starts deleting some.
-    :param default_timeout: the default timeout that is used if no timeout is
-                            specified on :meth:`~BaseCache.set`. A timeout of
-                            0 indicates that the cache never expires.
-    """
-
-    def __init__(
-        self,
-        threshold: int = 500,
-        default_timeout: int = 300,
-    ):
-        super().__init__(threshold=threshold, default_timeout=default_timeout)
-        self._lock = threading.RLock()
-
-    def get(self, key: str) -> _t.Any:
         with self._lock:
-            return super().get(key)
+            try:
+                expires, value = self._cache[key]
+                if expires == 0 or expires > time():
+                    return self.serializer.loads(value)
+            except KeyError:
+                return None
 
     def set(
         self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
     ) -> _t.Optional[bool]:
         with self._lock:
-            return super().set(key, value, timeout)
+            expires = self._normalize_timeout(timeout)
+            self._prune()
+            self._cache[key] = (expires, self.serializer.dumps(value))
+            return True
 
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
         with self._lock:
-            return super().add(key, value, timeout)
+            expires = self._normalize_timeout(timeout)
+            self._prune()
+            item = (expires, self.serializer.dumps(value))
+            # key exists and is not expired, do not add
+            if self.has(key):
+                return False
+            # key does not exist or is expired, add it
+            self._cache[key] = item
+            return True
 
     def delete(self, key: str) -> bool:
         with self._lock:
-            return super().delete(key)
+            return self._cache.pop(key, None) is not None
 
     def has(self, key: str) -> bool:
         with self._lock:
-            return super().has(key)
+            try:
+                expires, value = self._cache[key]
+                return bool(expires == 0 or expires > time())
+            except KeyError:
+                return False
 
     def clear(self) -> bool:
         with self._lock:
-            return super().clear()
+            self._cache.clear()
+            return not bool(self._cache)
 
     def inc(self, key: str, delta: int = 1) -> _t.Optional[int]:
         with self._lock:

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -1,3 +1,4 @@
+import threading
 import typing as _t
 from time import time
 
@@ -100,3 +101,72 @@ class SimpleCache(BaseCache):
     def clear(self) -> bool:
         self._cache.clear()
         return not bool(self._cache)
+
+
+class ThreadedSimpleCache(SimpleCache):
+    """A thread-safe variant of :class:`SimpleCache`.
+
+    All single-key operations (``get``, ``set``, ``add``, ``delete``, ``has``,
+    ``inc``, ``dec``, ``clear``) are protected by a reentrant lock
+    (``threading.RLock``), making this backend safe to share between
+    threads. A reentrant lock is required because ``inc`` and ``dec`` call
+    ``get`` and ``set`` internally, which would otherwise deadlock.
+
+    The batch helpers inherited from :class:`BaseCache` (``get_many``,
+    ``set_many``, ``delete_many``, ``get_dict``) acquire the lock for each
+    underlying single-key call but are **not** atomic across the whole
+    batch. Use single-key operations if you need an all-or-nothing
+    guarantee across multiple keys.
+
+    The API is otherwise identical to :class:`SimpleCache`. Use this
+    backend whenever your application serves requests from multiple
+    threads concurrently.
+
+    :param threshold: the maximum number of items the cache stores before
+                      it starts deleting some.
+    :param default_timeout: the default timeout that is used if no timeout is
+                            specified on :meth:`~BaseCache.set`. A timeout of
+                            0 indicates that the cache never expires.
+    """
+
+    def __init__(
+        self,
+        threshold: int = 500,
+        default_timeout: int = 300,
+    ):
+        super().__init__(threshold=threshold, default_timeout=default_timeout)
+        self._lock = threading.RLock()
+
+    def get(self, key: str) -> _t.Any:
+        with self._lock:
+            return super().get(key)
+
+    def set(
+        self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
+    ) -> _t.Optional[bool]:
+        with self._lock:
+            return super().set(key, value, timeout)
+
+    def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:
+        with self._lock:
+            return super().add(key, value, timeout)
+
+    def delete(self, key: str) -> bool:
+        with self._lock:
+            return super().delete(key)
+
+    def has(self, key: str) -> bool:
+        with self._lock:
+            return super().has(key)
+
+    def clear(self) -> bool:
+        with self._lock:
+            return super().clear()
+
+    def inc(self, key: str, delta: int = 1) -> _t.Optional[int]:
+        with self._lock:
+            return super().inc(key, delta)
+
+    def dec(self, key: str, delta: int = 1) -> _t.Optional[int]:
+        with self._lock:
+            return super().dec(key, delta)

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -8,8 +8,8 @@ from cachelib.serializers import SimpleSerializer
 
 class SimpleCache(BaseCache):
     """Simple memory cache for single process environments. All operations
-    are protected by a :class:`threading.RLock`, making this cache safe
-    to use in multi-threaded applications.
+    are protected by a :class:`threading.RLock`, making a cache instance safe
+    to use from multiple threads within the same process.
 
     :param threshold: the maximum number of items the cache stores before
                       it starts deleting some.

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -1,3 +1,4 @@
+import threading
 from time import sleep
 
 import pytest
@@ -6,6 +7,7 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import SimpleCache
+from cachelib import ThreadedSimpleCache
 
 
 class SillySerializer:
@@ -28,7 +30,7 @@ class CustomCache(SimpleCache):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(autouse=True, params=[SimpleCache, CustomCache])
+@pytest.fixture(params=[SimpleCache, CustomCache])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
         return request.param(*args, **kwargs)
@@ -36,6 +38,15 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
+@pytest.fixture(params=[ThreadedSimpleCache])
+def threaded_cache_factory(request):
+    def _factory(self, *args, **kwargs):
+        return request.param(*args, **kwargs)
+
+    request.cls.cache_factory = _factory
+
+
+@pytest.mark.usefixtures("cache_factory")
 class TestSimpleCache(CommonTests, HasTests, ClearTests):
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
@@ -77,3 +88,125 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests):
     def test_delete_nonexistent_returns_false(self):
         cache = self.cache_factory()
         assert cache.delete("does_not_exist") is False
+
+
+@pytest.mark.usefixtures("threaded_cache_factory")
+class TestThreadedSimpleCache(CommonTests, HasTests, ClearTests):
+    """Run the full common test suite against ThreadedSimpleCache."""
+
+    def test_concurrent_set_no_data_corruption(self):
+        """Multiple threads writing distinct keys must all succeed."""
+        cache = self.cache_factory()
+        errors = []
+
+        def writer(thread_id: int) -> None:
+            for i in range(50):
+                key = f"thread-{thread_id}-key-{i}"
+                try:
+                    cache.set(key, thread_id * 1000 + i)
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Exceptions raised during concurrent set: {errors}"
+
+    def test_concurrent_inc_is_consistent(self):
+        """Concurrent increments on a single key must not lose updates.
+
+        A small sleep is injected into ``serializer.dumps`` to widen the
+        read-modify-write window inside ``inc``. Without the cache's lock,
+        threads would interleave between ``get`` and ``set`` and lose
+        updates, making this test reliably fail on a non-thread-safe
+        backend.
+        """
+        cache = self.cache_factory()
+
+        class _SlowSerializer:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def dumps(self, value):
+                sleep(0.0001)
+                return self._inner.dumps(value)
+
+            def loads(self, bvalue):
+                return self._inner.loads(bvalue)
+
+        cache.serializer = _SlowSerializer(type(cache).serializer)
+        cache.set("counter", 0)
+        num_threads = 20
+        increments_each = 50
+        barrier = threading.Barrier(num_threads)
+
+        def incrementer() -> None:
+            barrier.wait()
+            for _ in range(increments_each):
+                cache.inc("counter", 1)
+
+        threads = [threading.Thread(target=incrementer) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert cache.get("counter") == num_threads * increments_each
+
+    def test_concurrent_add_only_one_winner(self):
+        """Only one thread must win the race on add() for a fresh key."""
+        cache = self.cache_factory()
+        results = []
+        lock = threading.Lock()
+
+        def adder() -> None:
+            result = cache.add("race-key", 1)
+            with lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=adder) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        winners = [r for r in results if r is True]
+        assert len(winners) == 1, f"Expected exactly 1 winner, got {len(winners)}"
+
+    def test_concurrent_get_set_no_exception(self):
+        """Simultaneous reads and writes must not raise exceptions."""
+        cache = self.cache_factory()
+        cache.set("shared", "initial")
+        errors = []
+
+        def reader() -> None:
+            for _ in range(100):
+                try:
+                    cache.get("shared")
+                except Exception as exc:
+                    errors.append(exc)
+
+        def writer() -> None:
+            for i in range(100):
+                try:
+                    cache.set("shared", i)
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(5)]
+        threads += [threading.Thread(target=writer) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Exceptions during concurrent get/set: {errors}"
+
+    def test_is_subclass_of_simple_cache(self):
+        """ThreadedSimpleCache must be a drop-in subclass of SimpleCache."""
+        cache = self.cache_factory()
+        assert isinstance(cache, ThreadedSimpleCache)
+        assert isinstance(cache, SimpleCache)

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -80,25 +80,41 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests):
         assert cache.delete("does_not_exist") is False
 
     def test_concurrent_set_no_data_corruption(self):
-        """Multiple threads writing distinct keys must all succeed."""
+        """Concurrent writes of distinct keys must preserve every value."""
         cache = self.cache_factory()
         errors = []
+        result_lock = threading.Lock()
+        num_threads = 10
+        writes_per_thread = 50
+        barrier = threading.Barrier(num_threads)
+        expected = {
+            f"thread-{thread_id}-key-{i}": thread_id * 1000 + i
+            for thread_id in range(num_threads)
+            for i in range(writes_per_thread)
+        }
 
         def writer(thread_id: int) -> None:
-            for i in range(50):
+            barrier.wait()
+
+            for i in range(writes_per_thread):
                 key = f"thread-{thread_id}-key-{i}"
                 try:
-                    cache.set(key, thread_id * 1000 + i)
+                    cache.set(key, expected[key])
                 except Exception as exc:
-                    errors.append(exc)
+                    with result_lock:
+                        errors.append(exc)
 
-        threads = [threading.Thread(target=writer, args=(t,)) for t in range(10)]
+        threads = [
+            threading.Thread(target=writer, args=(t,)) for t in range(num_threads)
+        ]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
         assert not errors, f"Exceptions raised during concurrent set: {errors}"
+        assert len(cache._cache) == len(expected)
+        assert cache.get_dict(*expected.keys()) == expected
 
     def test_concurrent_inc_is_consistent(self):
         """Concurrent increments on a single key must not lose updates."""
@@ -154,31 +170,75 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests):
         winners = [r for r in results if r is True]
         assert len(winners) == 1, f"Expected exactly 1 winner, got {len(winners)}"
 
-    def test_concurrent_get_set_no_exception(self):
-        """Simultaneous reads and writes must not raise exceptions."""
+    def test_concurrent_get_set_preserves_valid_shared_values(self):
+        """Concurrent readers must only observe complete values."""
         cache = self.cache_factory()
-        cache.set("shared", "initial")
+
+        class _SlowSerializer:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def dumps(self, value):
+                sleep(0.0001)
+                return self._inner.dumps(value)
+
+            def loads(self, bvalue):
+                sleep(0.0001)
+                return self._inner.loads(bvalue)
+
+        cache.serializer = _SlowSerializer(type(cache).serializer)
+
+        initial_value = ("initial", -1)
+        cache.set("shared", initial_value)
         errors = []
+        observed_values = []
+        result_lock = threading.Lock()
+        num_readers = 5
+        num_writers = 5
+        writes_per_writer = 100
+        barrier = threading.Barrier(num_readers + num_writers)
+        written_values = {
+            (thread_id, i)
+            for thread_id in range(num_writers)
+            for i in range(writes_per_writer)
+        }
+        expected_values = {initial_value} | written_values
 
         def reader() -> None:
-            for _ in range(100):
-                try:
-                    cache.get("shared")
-                except Exception as exc:
-                    errors.append(exc)
+            barrier.wait()
 
-        def writer() -> None:
-            for i in range(100):
+            for _ in range(writes_per_writer):
                 try:
-                    cache.set("shared", i)
+                    value = cache.get("shared")
+                    with result_lock:
+                        observed_values.append(value)
                 except Exception as exc:
-                    errors.append(exc)
+                    with result_lock:
+                        errors.append(exc)
 
-        threads = [threading.Thread(target=reader) for _ in range(5)]
-        threads += [threading.Thread(target=writer) for _ in range(5)]
+        def writer(thread_id: int) -> None:
+            barrier.wait()
+
+            for i in range(writes_per_writer):
+                try:
+                    cache.set("shared", (thread_id, i))
+                except Exception as exc:
+                    with result_lock:
+                        errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(num_readers)]
+        threads += [
+            threading.Thread(target=writer, args=(thread_id,))
+            for thread_id in range(num_writers)
+        ]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
         assert not errors, f"Exceptions during concurrent get/set: {errors}"
+        assert observed_values
+        assert set(observed_values) <= expected_values
+        assert len(cache._cache) == 1
+        assert cache.has("shared") is True
+        assert cache.get("shared") in written_values

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -7,7 +7,6 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import SimpleCache
-from cachelib import ThreadedSimpleCache
 
 
 class SillySerializer:
@@ -30,7 +29,7 @@ class CustomCache(SimpleCache):
         super().__init__(*args, **kwargs)
 
 
-@pytest.fixture(params=[SimpleCache, CustomCache])
+@pytest.fixture(autouse=True, params=[SimpleCache, CustomCache])
 def cache_factory(request):
     def _factory(self, *args, **kwargs):
         return request.param(*args, **kwargs)
@@ -38,15 +37,6 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
-@pytest.fixture(params=[ThreadedSimpleCache])
-def threaded_cache_factory(request):
-    def _factory(self, *args, **kwargs):
-        return request.param(*args, **kwargs)
-
-    request.cls.cache_factory = _factory
-
-
-@pytest.mark.usefixtures("cache_factory")
 class TestSimpleCache(CommonTests, HasTests, ClearTests):
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
@@ -89,11 +79,6 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests):
         cache = self.cache_factory()
         assert cache.delete("does_not_exist") is False
 
-
-@pytest.mark.usefixtures("threaded_cache_factory")
-class TestThreadedSimpleCache(CommonTests, HasTests, ClearTests):
-    """Run the full common test suite against ThreadedSimpleCache."""
-
     def test_concurrent_set_no_data_corruption(self):
         """Multiple threads writing distinct keys must all succeed."""
         cache = self.cache_factory()
@@ -116,14 +101,7 @@ class TestThreadedSimpleCache(CommonTests, HasTests, ClearTests):
         assert not errors, f"Exceptions raised during concurrent set: {errors}"
 
     def test_concurrent_inc_is_consistent(self):
-        """Concurrent increments on a single key must not lose updates.
-
-        A small sleep is injected into ``serializer.dumps`` to widen the
-        read-modify-write window inside ``inc``. Without the cache's lock,
-        threads would interleave between ``get`` and ``set`` and lose
-        updates, making this test reliably fail on a non-thread-safe
-        backend.
-        """
+        """Concurrent increments on a single key must not lose updates."""
         cache = self.cache_factory()
 
         class _SlowSerializer:
@@ -204,9 +182,3 @@ class TestThreadedSimpleCache(CommonTests, HasTests, ClearTests):
             t.join()
 
         assert not errors, f"Exceptions during concurrent get/set: {errors}"
-
-    def test_is_subclass_of_simple_cache(self):
-        """ThreadedSimpleCache must be a drop-in subclass of SimpleCache."""
-        cache = self.cache_factory()
-        assert isinstance(cache, ThreadedSimpleCache)
-        assert isinstance(cache, SimpleCache)


### PR DESCRIPTION
Add `ThreadedSimpleCache`, a thread-safe variant of `SimpleCache` that
wraps all single-key operations with a `threading.RLock`, making it
safe to use in multi-threaded environments. `SimpleCache` is left
unchanged since it is documented for single-process use only.

A reentrant lock (`RLock`) is used instead of a plain `Lock` because
`inc` and `dec` internally call `get` and `set` — a plain `Lock` would
deadlock. Batch operations (`get_many`, `set_many`, etc.) are locked
per individual call but are not atomic across the whole batch,
consistent with other backends.

fixes #446