### PR TITLE
feat: allow passing serializer on cache creation and implement JSONSerializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Version 0.15.0
 Unreleased
 
 - Make ``SimpleCache`` thread-safe using a ``threading.RLock``. :issue:`446`
+- Allow passing a custom ``serializer`` on cache creation and add ``JSONSerializer``. :pr:`462`
+
 
 Version 0.14.0
 --------------

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -2,6 +2,7 @@ import datetime
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import DynamoDbSerializer
 
 CREATED_AT_FIELD = "created_at"
@@ -33,10 +34,12 @@ class DynamoDbCache(BaseCache):
                                   this as the TTL field, then DynamoDB will
                                   automatically delete expired entries.
     :param key_prefix: A prefix that should be added to all keys.
-
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
     """
 
-    serializer = DynamoDbSerializer()
+    serializer: BaseSerializer = DynamoDbSerializer()
 
     def __init__(
         self,
@@ -45,6 +48,7 @@ class DynamoDbCache(BaseCache):
         key_field: _t.Optional[str] = "cache_key",
         expiration_time_field: _t.Optional[str] = "expiration_time",
         key_prefix: _t.Optional[str] = None,
+        serializer: _t.Optional[BaseSerializer] = None,
         **kwargs: _t.Any,
     ):
         super().__init__(default_timeout)
@@ -60,6 +64,8 @@ class DynamoDbCache(BaseCache):
         self.key_prefix = key_prefix or ""
         self._dynamo = boto3.resource("dynamodb", **kwargs)
         self._attr = boto3.dynamodb.conditions.Attr
+        if serializer is not None:
+            self.serializer = serializer
 
         try:
             self._table = self._dynamo.Table(table_name)
@@ -134,7 +140,7 @@ class DynamoDbCache(BaseCache):
         cache_item = self._get_item(self.key_prefix + key)
         if cache_item:
             response = cache_item[RESPONSE_FIELD]
-            value = self.serializer.loads(response)
+            value = self.serializer.loads(response.value)
             return value
         return None
 

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -13,6 +13,7 @@ from time import sleep
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import FileSystemSerializer
 
 
@@ -42,6 +43,9 @@ class FileSystemCache(BaseCache):
                         generate the filename for cached results.
                         Default is lazy loaded and can be overridden by
                         setting  `_default_hash_method`
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dump and load methods.
     """
 
     #: used for temporary files by the FileSystemCache
@@ -51,7 +55,7 @@ class FileSystemCache(BaseCache):
     #: default file name hashing method
     _default_hash_method = staticmethod(_lazy_md5)
 
-    serializer = FileSystemSerializer()
+    serializer: BaseSerializer = FileSystemSerializer()
 
     def __init__(
         self,
@@ -60,6 +64,7 @@ class FileSystemCache(BaseCache):
         default_timeout: int = 300,
         mode: _t.Optional[int] = None,
         hash_method: _t.Any = None,
+        serializer: _t.Optional[BaseSerializer] = None,
     ):
         BaseCache.__init__(self, default_timeout)
         self._path = cache_dir
@@ -75,6 +80,9 @@ class FileSystemCache(BaseCache):
         self._mode = mode
         if self._mode is None:
             self._mode = self._get_compatible_platform_mode()
+
+        if serializer is not None:
+            self.serializer = serializer
 
         try:
             os.makedirs(self._path)

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -4,6 +4,7 @@ import typing as _t
 
 from cachelib.base import BaseCache
 from cachelib.serializers import BaseSerializer
+from cachelib.serializers import MongoDbSerializer
 
 
 class MongoDbCache(BaseCache):
@@ -19,10 +20,12 @@ class MongoDbCache(BaseCache):
     :param default_timeout: Set the timeout in seconds after which cache entries
                             expire
     :param key_prefix: A prefix that should be added to all keys.
-
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
     """
 
-    serializer = BaseSerializer()
+    serializer: BaseSerializer = MongoDbSerializer()
 
     def __init__(
         self,
@@ -31,6 +34,7 @@ class MongoDbCache(BaseCache):
         collection: _t.Optional[str] = "cache-collection",
         default_timeout: int = 300,
         key_prefix: _t.Optional[str] = None,
+        serializer: _t.Optional[BaseSerializer] = None,
         **kwargs: _t.Any,
     ):
         super().__init__(default_timeout)
@@ -48,8 +52,11 @@ class MongoDbCache(BaseCache):
         }
         if "id" not in all_keys:
             self.client.create_index("id", unique=True)
+
         self.key_prefix = key_prefix or ""
         self.collection = collection
+        if serializer is not None:
+            self.serializer = serializer
 
     def _utcnow(self) -> _t.Any:
         """Return a tz-aware UTC datetime representing the current time"""

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -1,6 +1,7 @@
 import typing as _t
 
 from cachelib.redis_base import BaseRedisCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import RedisSerializer
 
 
@@ -22,6 +23,9 @@ class RedisCache(BaseRedisCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param key_prefix: A prefix that should be added to all keys.
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
 
     Any additional keyword arguments will be passed to ``redis.Redis``.
     """
@@ -36,6 +40,7 @@ class RedisCache(BaseRedisCache):
         db: int = 0,
         default_timeout: int = 300,
         key_prefix: _t.Optional[_t.Union[str, _t.Callable[[], str]]] = None,
+        serializer: _t.Optional[BaseSerializer] = None,
         **kwargs: _t.Any,
     ):
         if host is None:
@@ -52,4 +57,4 @@ class RedisCache(BaseRedisCache):
             )
         else:
             client = host
-        super().__init__(client, default_timeout, key_prefix)
+        super().__init__(client, default_timeout, key_prefix, serializer)

--- a/src/cachelib/redis_base.py
+++ b/src/cachelib/redis_base.py
@@ -2,6 +2,7 @@ import typing as _t
 
 from cachelib.base import BaseCache
 from cachelib.serializers import BaseRedisSerializer
+from cachelib.serializers import BaseSerializer
 
 
 class BaseRedisCache(BaseCache):
@@ -15,21 +16,27 @@ class BaseRedisCache(BaseCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param key_prefix: A prefix that should be added to all keys.
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
     """
 
     _read_client: _t.Any = None
     _write_client: _t.Any = None
-    serializer = BaseRedisSerializer()
+    serializer: BaseSerializer = BaseRedisSerializer()
 
     def __init__(
         self,
         client: _t.Any,
         default_timeout: int = 300,
         key_prefix: _t.Optional[_t.Union[str, _t.Callable[[], str]]] = None,
+        serializer: _t.Optional[BaseSerializer] = None,
     ):
         BaseCache.__init__(self, default_timeout)
         self._read_client = self._write_client = client
         self.key_prefix = key_prefix or ""
+        if serializer is not None:
+            self.serializer = serializer
 
     def _get_prefix(self) -> str:
         return (

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pickle
 import typing as _t
@@ -11,10 +12,8 @@ class BaseSerializer:
     used only by FileSystemCache which dumps/loads to/from a file stream.
     """
 
-    def _warn(self, e: pickle.PickleError) -> None:
-        logging.warning(
-            f"An exception has been raised during a pickling operation: {e}"
-        )
+    def _warn(self, e: Exception) -> None:
+        logging.warning(f"An exception has been raised during an operation: {e}")
 
     def dump(
         self, value: int, f: _t.IO[bytes], protocol: int = pickle.HIGHEST_PROTOCOL
@@ -119,9 +118,58 @@ class ValkeySerializer(BaseRedisSerializer):
 class DynamoDbSerializer(RedisSerializer):
     """Default serializer for DynamoDbCache."""
 
-    def loads(self, value: _t.Any) -> _t.Any:
-        """The reversal of :meth:`dump_object`. This might be called with
-        None.
-        """
-        value = value.value
-        return super().loads(value)
+    pass
+
+
+class MongoDbSerializer(BaseSerializer):
+    """Default serializer for MongoDbCache."""
+
+    pass
+
+
+class JSONSerializer(BaseSerializer):
+    """Generic JSON serializer for caches.
+
+    Use this serializer if you want to serialize to JSON instead of pickle.
+    Note that JSON does not support serialization of Python bytes objects.
+    If you need to cache bytes, use the default pickle-based serializer.
+    This serializer is not used by default.
+    """
+
+    def dump(
+        self, value: _t.Any, f: _t.IO[bytes], *args: _t.Any, **kwargs: _t.Any
+    ) -> None:
+        try:
+            f.write(json.dumps(value, *args, **kwargs).encode())
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+
+    def load(self, f: _t.IO[bytes], *args: _t.Any, **kwargs: _t.Any) -> _t.Any:
+        try:
+            data = json.loads(f.read(), *args, **kwargs)
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        else:
+            return data
+
+    def dumps(
+        self, value: _t.Any, *args: _t.Any, **kwargs: _t.Any
+    ) -> _t.Optional[bytes]:
+        try:
+            serialized = json.dumps(value, *args, **kwargs).encode()
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        return serialized
+
+    def loads(
+        self, bvalue: _t.Union[str, bytes, bytearray], *args: _t.Any, **kwargs: _t.Any
+    ) -> _t.Any:
+        try:
+            data = json.loads(bvalue, *args, **kwargs)
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        else:
+            return data

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -3,6 +3,7 @@ import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import SimpleSerializer
 
 
@@ -16,19 +17,25 @@ class SimpleCache(BaseCache):
     :param default_timeout: the default timeout that is used if no timeout is
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
     """
 
-    serializer = SimpleSerializer()
+    serializer: BaseSerializer = SimpleSerializer()
 
     def __init__(
         self,
         threshold: int = 500,
         default_timeout: int = 300,
+        serializer: _t.Optional[BaseSerializer] = None,
     ):
         BaseCache.__init__(self, default_timeout)
         self._cache: _t.Dict[str, _t.Any] = {}
         self._threshold = threshold or 500  # threshold = 0
         self._lock = threading.RLock()
+        if serializer is not None:
+            self.serializer = serializer
 
     def _over_threshold(self) -> bool:
         return len(self._cache) > self._threshold

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -2,6 +2,7 @@ import platform
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import UWSGISerializer
 
 
@@ -18,14 +19,18 @@ class UWSGICache(BaseCache):
         means uWSGI will cache in the local instance. If the cache is in the
         same instance as the werkzeug app, you only have to provide the name of
         the cache.
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
     """
 
-    serializer = UWSGISerializer()
+    serializer: BaseSerializer = UWSGISerializer()
 
     def __init__(
         self,
         default_timeout: int = 300,
         cache: str = "",
+        serializer: _t.Optional[BaseSerializer] = None,
     ):
         BaseCache.__init__(self, default_timeout)
 
@@ -44,6 +49,8 @@ class UWSGICache(BaseCache):
             ) from err
 
         self.cache = cache
+        if serializer is not None:
+            self.serializer = serializer
 
     def get(self, key: str) -> _t.Any:
         rv = self._uwsgi.cache_get(key, self.cache)

--- a/src/cachelib/valkey.py
+++ b/src/cachelib/valkey.py
@@ -1,6 +1,7 @@
 import typing as _t
 
 from cachelib.redis_base import BaseRedisCache
+from cachelib.serializers import BaseSerializer
 from cachelib.serializers import ValkeySerializer
 
 
@@ -22,6 +23,9 @@ class ValkeyCache(BaseRedisCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param key_prefix: A prefix that should be added to all keys.
+    :param serializer: An optional serializer to use instead of the default
+                       BaseSerializer. The serializer must implement the
+                       dumps and loads methods.
 
     Any additional keyword arguments will be passed to ``valkey.Valkey``.
     """
@@ -36,6 +40,7 @@ class ValkeyCache(BaseRedisCache):
         db: int = 0,
         default_timeout: int = 300,
         key_prefix: _t.Optional[_t.Union[str, _t.Callable[[], str]]] = None,
+        serializer: _t.Optional[BaseSerializer] = None,
         **kwargs: _t.Any,
     ):
         if host is None:
@@ -52,7 +57,7 @@ class ValkeyCache(BaseRedisCache):
             )
         else:
             client = host
-        super().__init__(client, default_timeout, key_prefix)
+        super().__init__(client, default_timeout, key_prefix, serializer)
 
     def set_many(
         self, mapping: _t.Dict[str, _t.Any], timeout: _t.Optional[int] = None

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -1,0 +1,40 @@
+from conftest import TestData
+
+from cachelib.serializers import JSONSerializer
+
+
+class SerializerTests(TestData):
+    """A set of tests to run on serializers used by caches"""
+
+    def test_serializer_injection_roundtrip(self):
+        cache = self.cache_factory(serializer=JSONSerializer())
+        assert cache.set("key", {"a": 1, "b": [1, 2, 3]})
+        assert cache.get("key") == {"a": 1, "b": [1, 2, 3]}
+
+    def test_serializer_injection_set_many(self):
+        cache = self.cache_factory(serializer=JSONSerializer())
+        pairs = {"k1": "hello", "k2": 42, "k3": [True, None]}
+        assert cache.set_many(pairs)
+        assert cache.get_many(*pairs) == list(pairs.values())
+
+    def test_serializer_is_stored_on_instance(self):
+        serializer = JSONSerializer()
+        cache = self.cache_factory(serializer=serializer)
+        assert isinstance(cache.serializer, JSONSerializer)
+
+    def test_serializer_injection_add(self):
+        cache = self.cache_factory(serializer=JSONSerializer())
+        assert cache.add("key", {"a": 1})
+        assert cache.get("key") == {"a": 1}
+        assert not cache.add("key", {"b": 2})
+
+    def test_serializer_injection_get_dict(self):
+        cache = self.cache_factory(serializer=JSONSerializer())
+        pairs = {"k1": "hello", "k2": 42}
+        cache.set_many(pairs)
+        assert cache.get_dict(*pairs) == pairs
+
+    def test_no_serializer_uses_default(self):
+        cache = self.cache_factory()
+        assert cache.set("key", b"raw bytes")
+        assert cache.get("key") == b"raw bytes"

--- a/tests/test_dynamodb_cache.py
+++ b/tests/test_dynamodb_cache.py
@@ -3,6 +3,7 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import DynamoDbCache
 
@@ -30,5 +31,7 @@ def cache_factory(request):
         request.cls.cache_factory = _factory
 
 
-class TestDynamoDbCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestDynamoDbCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     pass

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -8,6 +8,7 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import FileSystemCache
 
@@ -68,7 +69,7 @@ def cache_factory(request, tmpdir):
     request.cls.cache_factory = _factory
 
 
-class TestFileSystemCache(CommonTests, ClearTests, HasTests):
+class TestFileSystemCache(CommonTests, ClearTests, HasTests, SerializerTests):
     # override parent sample since these must implement buffer interface
     sample_pairs = {
         "bacon": "eggs",

--- a/tests/test_mongodb_cache.py
+++ b/tests/test_mongodb_cache.py
@@ -2,6 +2,7 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib.mongodb import MongoDbCache
 
@@ -26,5 +27,5 @@ def cache_factory(request):
         request.cls.cache_factory = _factory
 
 
-class TestMongoDbCache(CommonTests, ClearTests, HasTests):
+class TestMongoDbCache(CommonTests, ClearTests, HasTests, SerializerTests):
     pass

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -3,6 +3,7 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import RedisCache
 
@@ -44,7 +45,9 @@ def my_callable_key() -> str:
 
 
 @pytest.mark.usefixtures("redis_server")
-class TestRedisCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestRedisCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     def test_callable_key(self):
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,144 @@
+import io
+import pickle
+
+import pytest
+
+from cachelib.serializers import BaseRedisSerializer
+from cachelib.serializers import BaseSerializer
+from cachelib.serializers import JSONSerializer
+from cachelib.serializers import RedisSerializer
+from cachelib.serializers import ValkeySerializer
+
+PICKLE_VALUES = [
+    None,
+    True,
+    False,
+    0,
+    42,
+    -1,
+    3.14,
+    "",
+    "hello",
+    b"raw bytes",
+    [],
+    [1, 2, 3],
+    (1, 2),
+    {},
+    {"a": 1, "b": [True, None]},
+]
+
+JSON_VALUES = [v for v in PICKLE_VALUES if not isinstance(v, (bytes, tuple))]
+
+
+class _Unpicklable:
+    """Helper that always raises PicklingError"""
+
+    def __reduce__(self):
+        raise pickle.PicklingError("cannot pickle")
+
+
+class TestBaseSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = BaseSerializer()
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dump_load_roundtrip(self, value):
+        buf = io.BytesIO()
+        self.s.dump(value, buf)
+        buf.seek(0)
+        assert self.s.load(buf) == value
+
+    def test_dumps_returns_none_on_pickle_error(self):
+        assert self.s.dumps(_Unpicklable()) is None
+
+    def test_loads_returns_none_on_corrupt_data(self):
+        assert self.s.loads(b"not valid pickle data") is None
+
+    def test_load_returns_none_on_corrupt_stream(self):
+        assert self.s.load(io.BytesIO(b"not valid pickle data")) is None
+
+
+class TestBaseRedisSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = BaseRedisSerializer()
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    def test_dumps_adds_bang_prefix(self):
+        assert self.s.dumps("hello").startswith(b"!")
+
+    def test_loads_none_returns_none(self):
+        assert self.s.loads(None) is None
+
+    @pytest.mark.parametrize("n", [0, 1, 42, -5])
+    def test_loads_integer_string_returns_int(self, n):
+        # Redis stores counters as plain integers without prefix
+        assert self.s.loads(str(n).encode()) == n
+
+    def test_loads_legacy_bytes_returns_raw(self):
+        # Before 0.8, values were stored without the "!" prefix
+        raw = b"legacy data without prefix"
+        assert self.s.loads(raw) == raw
+
+    def test_loads_corrupt_prefixed_data_returns_none(self):
+        assert self.s.loads(b"!" + b"corrupt pickle") is None
+
+
+@pytest.mark.parametrize("cls", [RedisSerializer, ValkeySerializer])
+class TestRedisCompatibleSerializers:
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_roundtrip(self, cls, value):
+        s = cls()
+        assert s.loads(s.dumps(value)) == value
+
+
+class TestJSONSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = JSONSerializer()
+
+    @pytest.mark.parametrize("value", JSON_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    @pytest.mark.parametrize("value", JSON_VALUES)
+    def test_dump_load_roundtrip(self, value):
+        buf = io.BytesIO()
+        self.s.dump(value, buf)
+        buf.seek(0)
+        assert self.s.load(buf) == value
+
+    def test_dumps_returns_bytes(self):
+        assert isinstance(self.s.dumps({"key": "value"}), bytes)
+
+    def test_dump_writes_bytes_to_stream(self):
+        buf = io.BytesIO()
+        self.s.dump({"key": "value"}, buf)
+        assert isinstance(buf.getvalue(), bytes)
+        assert buf.getvalue()
+
+    @pytest.mark.parametrize("value", [b"raw bytes", _Unpicklable()])
+    def test_dumps_non_serializable_returns_none(self, value):
+        assert self.s.dumps(value) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        [b'"hello"', '"hello"', bytearray(b'"hello"')],
+        ids=["bytes", "str", "bytearray"],
+    )
+    def test_loads_accepts_bytes_str_bytearray(self, raw):
+        assert self.s.loads(raw) == "hello"
+
+    def test_loads_invalid_json_returns_none(self):
+        assert self.s.loads(b"not valid json {{{{") is None
+
+    def test_load_invalid_stream_returns_none(self):
+        assert self.s.load(io.BytesIO(b"not valid json {{{{")) is None

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -5,11 +5,13 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import SimpleCache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):
@@ -37,7 +39,7 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
-class TestSimpleCache(CommonTests, HasTests, ClearTests):
+class TestSimpleCache(CommonTests, HasTests, ClearTests, SerializerTests):
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
         cache = self.cache_factory(threshold=threshold)

--- a/tests/test_uwsgi_cache.py
+++ b/tests/test_uwsgi_cache.py
@@ -4,9 +4,10 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import UWSGICache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):

--- a/tests/test_valkey_cache.py
+++ b/tests/test_valkey_cache.py
@@ -3,11 +3,13 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import ValkeyCache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):
@@ -44,7 +46,9 @@ def my_callable_key() -> str:
 
 
 @pytest.mark.usefixtures("valkey_server")
-class TestValkeyCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestValkeyCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     def test_callable_key(self):
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")


### PR DESCRIPTION
Allows people to pass the serializers when creating an instance of the class while maintaining a default to pickle serializer if no value is passed.

 Adds an implementation of a JSON serializer that only handles the types handled by the [`json`](https://docs.python.org/3/library/json.html) library

closes #136 and related to https://github.com/pallets-eco/flask-caching/pull/209
It should simplify the implementation of https://github.com/pallets-eco/flask-caching/pull/209 as backends will accept them as inputs now without rewriting the backend.