### PR TITLE
Small Code Cleanups

### DIFF
--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -29,6 +29,8 @@ class MemcachedCache(BaseCache):
     the keys in the same format as passed.  Furthermore all get methods
     silently ignore key errors to not cause problems when untrusted user data
     is passed to the get methods which is often the case in web applications.
+    This cache doesn't have a serializer since the underlying memcached client
+    libraries handle serialization internally."
 
     :param servers: a list or tuple of server addresses or alternatively
                     a :class:`memcache.Client` or a compatible client.

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -1,9 +1,8 @@
 import datetime
-import logging
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.serializers import BaseSerializer
+from cachelib.serializers import MongoDbSerializer
 
 
 class MongoDbCache(BaseCache):
@@ -22,7 +21,7 @@ class MongoDbCache(BaseCache):
 
     """
 
-    serializer = BaseSerializer()
+    serializer = MongoDbSerializer()
 
     def __init__(
         self,
@@ -36,11 +35,11 @@ class MongoDbCache(BaseCache):
         super().__init__(default_timeout)
         try:
             import pymongo
-        except ImportError:
-            logging.warning("no pymongo module found")
+        except ImportError as err:
+            raise RuntimeError("no pymongo module found") from err
 
         if client is None or isinstance(client, str):
-            client = pymongo.MongoClient(host=client)
+            client = pymongo.MongoClient(host=client, **kwargs)
         self.client = client[db][collection]
         index_info = self.client.index_information()
         all_keys = {

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -125,3 +125,9 @@ class DynamoDbSerializer(RedisSerializer):
         """
         value = value.value
         return super().loads(value)
+
+
+class MongoDbSerializer(BaseSerializer):
+    """Default serializer for MongoDbCache."""
+
+    pass

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -56,13 +56,13 @@ class UWSGICache(BaseCache):
 
     def set(
         self, key: str, value: _t.Any, timeout: _t.Optional[int] = None
-    ) -> _t.Optional[bool]:
+    ) -> _t.Optional[_t.Literal[True]]:
         result = self._uwsgi.cache_update(
             key,
             self.serializer.dumps(value),
             self._normalize_timeout(timeout),
             self.cache,
-        )  # type: bool
+        )  # type: _t.Optional[_t.Literal[True]]
         return result
 
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> bool:


### PR DESCRIPTION
- Add note about `memcached` serializer.
- Add `MongoDB` serializer and raise same error as other backends after initializing `pymongo` so it's not unbound and receive kwargs like other backends.
- Fix type of return according to `uWsgi` library.

I don't think a change entry is needed for these changes.. if needed happy to add it.