### PR TITLE
fix: replace deprecated `setx` with `set` and refactor timeout check

### DIFF
--- a/src/cachelib/redis_base.py
+++ b/src/cachelib/redis_base.py
@@ -62,14 +62,11 @@ class BaseRedisCache(BaseCache):
     def set(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
         timeout = self._normalize_timeout(timeout)
         dump = self.serializer.dumps(value)
-        if timeout == -1:
-            result = self._write_client.set(
-                name=f"{self._get_prefix()}{key}", value=dump
-            )
-        else:
-            result = self._write_client.setex(
-                name=f"{self._get_prefix()}{key}", value=dump, time=timeout
-            )
+        result = self._write_client.set(
+            name=f"{self._get_prefix()}{key}",
+            value=dump,
+            ex=timeout if timeout != -1 else None,
+        )
         return result
 
     def add(self, key: str, value: _t.Any, timeout: _t.Optional[int] = None) -> _t.Any:
@@ -93,10 +90,11 @@ class BaseRedisCache(BaseCache):
 
         for key, value in mapping.items():
             dump = self.serializer.dumps(value)
-            if timeout == -1:
-                pipe.set(name=f"{self._get_prefix()}{key}", value=dump)
-            else:
-                pipe.setex(name=f"{self._get_prefix()}{key}", value=dump, time=timeout)
+            pipe.set(
+                name=f"{self._get_prefix()}{key}",
+                value=dump,
+                ex=timeout if timeout != -1 else None,
+            )
         results = pipe.execute()
         return [k for k, was_set in zip(mapping.keys(), results) if was_set]
 

--- a/src/cachelib/valkey.py
+++ b/src/cachelib/valkey.py
@@ -63,9 +63,10 @@ class ValkeyCache(BaseRedisCache):
 
         for key, value in mapping.items():
             dump = self.serializer.dumps(value)
-            if timeout == -1:
-                pipe.set(name=f"{self._get_prefix()}{key}", value=dump)
-            else:
-                pipe.setex(name=f"{self._get_prefix()}{key}", value=dump, time=timeout)
+            pipe.set(
+                name=f"{self._get_prefix()}{key}",
+                value=dump,
+                ex=timeout if timeout != -1 else None,
+            )
         results = pipe.execute()
         return [k for k, was_set in zip(mapping.keys(), results) if was_set]


### PR DESCRIPTION
While running tests locally I noticed the deprecation warning from `setx` making the change to `set` I also noticed that the check for timeout is no longer needed since both will use the set function.