### PR TITLE
create one mongo client and close the connection after using it in tests

### DIFF
--- a/tests/test_mongodb_cache.py
+++ b/tests/test_mongodb_cache.py
@@ -1,3 +1,4 @@
+import pymongo
 import pytest
 from clear import ClearTests
 from common import CommonTests
@@ -8,7 +9,10 @@ from cachelib.mongodb import MongoDbCache
 
 @pytest.fixture(autouse=True, params=[MongoDbCache])
 def cache_factory(request):
+    client = pymongo.MongoClient()
+
     def _factory(self, *args, **kwargs):
+        kwargs["client"] = client
         kwargs["db"] = "test-db"
         kwargs["collection"] = "test-collection"
         kwargs["key_prefix"] = "prefix"
@@ -24,6 +28,10 @@ def cache_factory(request):
 
     if request.cls:
         request.cls.cache_factory = _factory
+
+    yield
+
+    client.close()
 
 
 class TestMongoDbCache(CommonTests, ClearTests, HasTests):

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -49,5 +49,6 @@ class TestRedisCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTest
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")
         assert cache.get(my_callable_key) == "sausages"
-        assert cache.set(lambda: "spam", "sausages")
-        assert cache.get(lambda: "spam") == "sausages"
+        spam_key = lambda: "spam"  # noqa: E731
+        assert cache.set(spam_key, "sausages")
+        assert cache.get(spam_key) == "sausages"

--- a/tests/test_valkey_cache.py
+++ b/tests/test_valkey_cache.py
@@ -49,5 +49,6 @@ class TestValkeyCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTes
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")
         assert cache.get(my_callable_key) == "sausages"
-        assert cache.set(lambda: "spam", "sausages")
-        assert cache.get(lambda: "spam") == "sausages"
+        spam_key = lambda: "spam"  # noqa: E731
+        assert cache.set(spam_key, "sausages")
+        assert cache.get(spam_key) == "sausages"


### PR DESCRIPTION
The mongo client raises a warning for unclosed connections flooding the logs when running the tests so I changed the tests to create, reuse and close the connection to mongo
