### PR TITLE
feat: add json serializer and serializer tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.16.0
 
 Unreleased
 
+- Add ``JSONSerializer`` serializer and use the same base class for DynamoDB serialization. :pr:`489`
+
 
 Version 0.15.0
 --------------

--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ from cachelib import SimpleCache
 cache = SimpleCache()
 
 # Set a value in the cache
-cache.set('my_key', 'my_value')
+cache.set("my_key", "my_value")
 
 # Retrieve the value from the cache
-value = cache.get('my_key')
+value = cache.get("my_key")
 print(value)  # Output: my_value
 
 # Delete the value from the cache
-cache.delete('my_key')
+cache.delete("my_key")
 
 # Try to retrieve the deleted value
-value = cache.get('my_key')
+value = cache.get("my_key")
 print(value)  # Output: None
 ```

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -140,7 +140,7 @@ class DynamoDbCache(BaseCache):
         cache_item = self._get_item(self.key_prefix + key)
         if cache_item:
             response = cache_item[RESPONSE_FIELD]
-            value = self.serializer.loads(response)
+            value = self.serializer.loads(response.value)
             return value
         return None
 

--- a/src/cachelib/serializers.py
+++ b/src/cachelib/serializers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pickle
 import typing as _t
@@ -11,10 +12,8 @@ class BaseSerializer:
     used only by FileSystemCache which dumps/loads to/from a file stream.
     """
 
-    def _warn(self, e: pickle.PickleError) -> None:
-        logging.warning(
-            f"An exception has been raised during a pickling operation: {e}"
-        )
+    def _warn(self, e: Exception) -> None:
+        logging.warning(f"An exception has been raised during an operation: {e}")
 
     def dump(
         self, value: int, f: _t.IO[bytes], protocol: int = pickle.HIGHEST_PROTOCOL
@@ -83,6 +82,52 @@ class BaseRedisSerializer(BaseSerializer):
             return value
 
 
+class JSONSerializer(BaseSerializer):
+    """Generic JSON serializer for caches.
+
+    Use this serializer if you want to serialize to JSON instead of pickle.
+    Note that JSON does not support serialization of Python bytes objects.
+    If you need to cache bytes, use the default pickle-based serializer.
+    This serializer is not used by default.
+    """
+
+    def dump(
+        self, value: _t.Any, f: _t.IO[bytes], *args: _t.Any, **kwargs: _t.Any
+    ) -> None:
+        try:
+            f.write(json.dumps(value, *args, **kwargs).encode())
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+
+    def load(self, f: _t.IO[bytes], *args: _t.Any, **kwargs: _t.Any) -> _t.Any:
+        try:
+            data = json.loads(f.read(), *args, **kwargs)
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        else:
+            return data
+
+    def dumps(self, value: _t.Any, *args: _t.Any, **kwargs: _t.Any) -> bytes | None:
+        try:
+            serialized = json.dumps(value, *args, **kwargs).encode()
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        return serialized
+
+    def loads(
+        self, bvalue: str | bytes | bytearray, *args: _t.Any, **kwargs: _t.Any
+    ) -> _t.Any:
+        try:
+            data = json.loads(bvalue, *args, **kwargs)
+        except (TypeError, ValueError) as e:
+            self._warn(e)
+            return None
+        else:
+            return data
+
+
 """Default serializers for each cache type.
 
 The following classes can be used to further customize
@@ -118,10 +163,3 @@ class ValkeySerializer(BaseRedisSerializer):
 
 class DynamoDbSerializer(BaseRedisSerializer):
     """Default serializer for DynamoDbCache."""
-
-    def loads(self, value: _t.Any) -> _t.Any:
-        """The reversal of :meth:`BaseRedisSerializer.dumps`. This might be called with
-        None.
-        """
-        value = value.value
-        return super().loads(value)

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -1,0 +1,45 @@
+from conftest import TestData
+
+from cachelib.serializers import JSONSerializer
+
+
+class SerializerTests(TestData):
+    """A set of tests to run on serializers used by caches"""
+
+    def test_serializer_injection_roundtrip(self):
+        cache = self.cache_factory()
+        cache.serializer = JSONSerializer()
+        assert cache.set("key", {"a": 1, "b": [1, 2, 3]})
+        assert cache.get("key") == {"a": 1, "b": [1, 2, 3]}
+
+    def test_serializer_injection_set_many(self):
+        cache = self.cache_factory()
+        cache.serializer = JSONSerializer()
+        pairs = {"k1": "hello", "k2": 42, "k3": [True, None]}
+        assert cache.set_many(pairs)
+        assert cache.get_many(*pairs) == list(pairs.values())
+
+    def test_serializer_is_stored_on_instance(self):
+        serializer = JSONSerializer()
+        cache = self.cache_factory()
+        cache.serializer = serializer
+        assert isinstance(cache.serializer, JSONSerializer)
+
+    def test_serializer_injection_add(self):
+        cache = self.cache_factory()
+        cache.serializer = JSONSerializer()
+        assert cache.add("key", {"a": 1})
+        assert cache.get("key") == {"a": 1}
+        assert not cache.add("key", {"b": 2})
+
+    def test_serializer_injection_get_dict(self):
+        cache = self.cache_factory()
+        cache.serializer = JSONSerializer()
+        pairs = {"k1": "hello", "k2": 42}
+        cache.set_many(pairs)
+        assert cache.get_dict(*pairs) == pairs
+
+    def test_no_serializer_uses_default(self):
+        cache = self.cache_factory()
+        assert cache.set("key", b"raw bytes")
+        assert cache.get("key") == b"raw bytes"

--- a/tests/test_dynamodb_cache.py
+++ b/tests/test_dynamodb_cache.py
@@ -3,6 +3,7 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import DynamoDbCache
 
@@ -31,5 +32,7 @@ def cache_factory(request):
 
 
 @pytest.mark.network
-class TestDynamoDbCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestDynamoDbCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     pass

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -8,11 +8,13 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import FileSystemCache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dump(self, value, fs):
@@ -68,7 +70,7 @@ def cache_factory(request, tmpdir):
     request.cls.cache_factory = _factory
 
 
-class TestFileSystemCache(CommonTests, ClearTests, HasTests):
+class TestFileSystemCache(CommonTests, ClearTests, HasTests, SerializerTests):
     # override parent sample since these must implement buffer interface
     sample_pairs = {
         "bacon": "eggs",

--- a/tests/test_mongodb_cache.py
+++ b/tests/test_mongodb_cache.py
@@ -3,6 +3,7 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib.mongodb import MongoDbCache
 
@@ -35,5 +36,5 @@ def cache_factory(request):
 
 
 @pytest.mark.network
-class TestMongoDbCache(CommonTests, ClearTests, HasTests):
+class TestMongoDbCache(CommonTests, ClearTests, HasTests, SerializerTests):
     pass

--- a/tests/test_redis_cache.py
+++ b/tests/test_redis_cache.py
@@ -3,11 +3,13 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import RedisCache
+from cachelib.serializers import BaseRedisSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseRedisSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):
@@ -45,7 +47,9 @@ def my_callable_key() -> str:
 
 @pytest.mark.network
 @pytest.mark.usefixtures("redis_server")
-class TestRedisCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestRedisCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     def test_callable_key(self):
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,144 @@
+import io
+import pickle
+
+import pytest
+
+from cachelib.serializers import BaseRedisSerializer
+from cachelib.serializers import BaseSerializer
+from cachelib.serializers import JSONSerializer
+from cachelib.serializers import RedisSerializer
+from cachelib.serializers import ValkeySerializer
+
+PICKLE_VALUES = [
+    None,
+    True,
+    False,
+    0,
+    42,
+    -1,
+    3.14,
+    "",
+    "hello",
+    b"raw bytes",
+    [],
+    [1, 2, 3],
+    (1, 2),
+    {},
+    {"a": 1, "b": [True, None]},
+]
+
+JSON_VALUES = [v for v in PICKLE_VALUES if not isinstance(v, (bytes, tuple))]
+
+
+class _Unpicklable:
+    """Helper that always raises PicklingError"""
+
+    def __reduce__(self):
+        raise pickle.PicklingError("cannot pickle")
+
+
+class TestBaseSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = BaseSerializer()
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dump_load_roundtrip(self, value):
+        buf = io.BytesIO()
+        self.s.dump(value, buf)
+        buf.seek(0)
+        assert self.s.load(buf) == value
+
+    def test_dumps_returns_none_on_pickle_error(self):
+        assert self.s.dumps(_Unpicklable()) is None
+
+    def test_loads_returns_none_on_corrupt_data(self):
+        assert self.s.loads(b"not valid pickle data") is None
+
+    def test_load_returns_none_on_corrupt_stream(self):
+        assert self.s.load(io.BytesIO(b"not valid pickle data")) is None
+
+
+class TestBaseRedisSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = BaseRedisSerializer()
+
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    def test_dumps_adds_bang_prefix(self):
+        assert self.s.dumps("hello").startswith(b"!")
+
+    def test_loads_none_returns_none(self):
+        assert self.s.loads(None) is None
+
+    @pytest.mark.parametrize("n", [0, 1, 42, -5])
+    def test_loads_integer_string_returns_int(self, n):
+        # Redis stores counters as plain integers without prefix
+        assert self.s.loads(str(n).encode()) == n
+
+    def test_loads_legacy_bytes_returns_raw(self):
+        # Before 0.8, values were stored without the "!" prefix
+        raw = b"legacy data without prefix"
+        assert self.s.loads(raw) == raw
+
+    def test_loads_corrupt_prefixed_data_returns_none(self):
+        assert self.s.loads(b"!" + b"corrupt pickle") is None
+
+
+@pytest.mark.parametrize("cls", [RedisSerializer, ValkeySerializer])
+class TestRedisCompatibleSerializers:
+    @pytest.mark.parametrize("value", PICKLE_VALUES)
+    def test_roundtrip(self, cls, value):
+        s = cls()
+        assert s.loads(s.dumps(value)) == value
+
+
+class TestJSONSerializer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.s = JSONSerializer()
+
+    @pytest.mark.parametrize("value", JSON_VALUES)
+    def test_dumps_loads_roundtrip(self, value):
+        assert self.s.loads(self.s.dumps(value)) == value
+
+    @pytest.mark.parametrize("value", JSON_VALUES)
+    def test_dump_load_roundtrip(self, value):
+        buf = io.BytesIO()
+        self.s.dump(value, buf)
+        buf.seek(0)
+        assert self.s.load(buf) == value
+
+    def test_dumps_returns_bytes(self):
+        assert isinstance(self.s.dumps({"key": "value"}), bytes)
+
+    def test_dump_writes_bytes_to_stream(self):
+        buf = io.BytesIO()
+        self.s.dump({"key": "value"}, buf)
+        assert isinstance(buf.getvalue(), bytes)
+        assert buf.getvalue()
+
+    @pytest.mark.parametrize("value", [b"raw bytes", _Unpicklable()])
+    def test_dumps_non_serializable_returns_none(self, value):
+        assert self.s.dumps(value) is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        [b'"hello"', '"hello"', bytearray(b'"hello"')],
+        ids=["bytes", "str", "bytearray"],
+    )
+    def test_loads_accepts_bytes_str_bytearray(self, raw):
+        assert self.s.loads(raw) == "hello"
+
+    def test_loads_invalid_json_returns_none(self):
+        assert self.s.loads(b"not valid json {{{{") is None
+
+    def test_load_invalid_stream_returns_none(self):
+        assert self.s.load(io.BytesIO(b"not valid json {{{{")) is None

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -5,11 +5,13 @@ import pytest
 from clear import ClearTests
 from common import CommonTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import SimpleCache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):
@@ -37,7 +39,7 @@ def cache_factory(request):
     request.cls.cache_factory = _factory
 
 
-class TestSimpleCache(CommonTests, HasTests, ClearTests):
+class TestSimpleCache(CommonTests, HasTests, ClearTests, SerializerTests):
     def test_threshold(self):
         threshold = len(self.sample_pairs) // 2
         cache = self.cache_factory(threshold=threshold)

--- a/tests/test_uwsgi_cache.py
+++ b/tests/test_uwsgi_cache.py
@@ -4,9 +4,10 @@ from common import CommonTests
 from has import HasTests
 
 from cachelib import UWSGICache
+from cachelib.serializers import BaseSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):

--- a/tests/test_valkey_cache.py
+++ b/tests/test_valkey_cache.py
@@ -3,11 +3,13 @@ from clear import ClearTests
 from common import CommonTests
 from delete_many_with_prefix import DeleteManyWithPrefixTests
 from has import HasTests
+from serializer import SerializerTests
 
 from cachelib import ValkeyCache
+from cachelib.serializers import BaseRedisSerializer
 
 
-class SillySerializer:
+class SillySerializer(BaseRedisSerializer):
     """A pointless serializer only for testing"""
 
     def dumps(self, value):
@@ -45,7 +47,9 @@ def my_callable_key() -> str:
 
 @pytest.mark.network
 @pytest.mark.usefixtures("valkey_server")
-class TestValkeyCache(CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests):
+class TestValkeyCache(
+    CommonTests, ClearTests, HasTests, DeleteManyWithPrefixTests, SerializerTests
+):
     def test_callable_key(self):
         cache = self.cache_factory()
         assert cache.set(my_callable_key, "sausages")


### PR DESCRIPTION
Add an implementation of a JSON serializer that only handles the types handled by the [`json`](https://docs.python.org/3/library/json.html) library

related to #136 and related to https://github.com/pallets-eco/flask-caching/pull/209