### PR TITLE
release version 0.15.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Version 0.16.0
 unreleased
 
 
+Version 0.15.2
+---------------
+
+Released 2026-08-07
+
+- Fix ``libmc`` in ``MemcachedCache`` no reserve nor blocking. :pr:`493`
+
+
 Version 0.15.1
 ---------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cachelib"
-version = "0.15.1"
+version = "0.15.2"
 description = "A collection of cache libraries in the same API interface."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     "MongoDbCache",
     "ValkeyCache",
 ]
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/uv.lock
+++ b/uv.lock
@@ -149,7 +149,7 @@ wheels = [
 
 [[package]]
 name = "cachelib"
-version = "0.15.1"
+version = "0.15.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Fix ``libmc`` in ``MemcachedCache`` no reserve nor blocking. #493