### PR TITLE
use sha256 instead of md5 because of FIPs envs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 0.16.0
 
 unreleased
 
+- Change ``FileSystemCache`` default hash method to ``hashlib.sha256``
+  because ``hashlib.md5`` is not available in FIPS builds. :pr:`500`
+
 
 Version 0.15.4
 ---------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Version 0.16.0
 unreleased
 
 - Change ``FileSystemCache`` default hash method to ``hashlib.sha256``
-  because ``hashlib.md5`` is not available in FIPS builds. :pr:`500`
+  because ``hashlib.md5`` is not available in FIPS builds. :issue:`500`
 
 
 Version 0.15.4

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -16,14 +16,6 @@ from cachelib.base import BaseCache
 from cachelib.serializers import FileSystemSerializer
 
 
-def _lazy_md5(string: bytes = b"") -> _t.Any:
-    """Don't access :func:`~hashlib.md5` until runtime. FIPS builds may not include
-    md5, in which case the import and use as a default would fail before the
-    developer can configure something else.
-    """
-    return hashlib.md5(string)
-
-
 class FileSystemCache(BaseCache):
     """A cache that stores the items on the file system.  This cache depends
     on being the only user of the ``cache_dir``.  Make absolutely sure that
@@ -38,18 +30,14 @@ class FileSystemCache(BaseCache):
         specified on :meth:`~.BaseCache.set`. A timeout of
         0 indicates that the cache never expires.
     :param mode: the file mode wanted for the cache files, default 0600
-    :param hash_method: Default :func:`~hashlib.md5`. The hash method used to
+    :param hash_method: Default :func:`~hashlib.sha256`. The hash method used to
         generate the filename for cached results.
-        Default is lazy loaded and can be overridden by
-        setting  ``_default_hash_method``
     """
 
     #: used for temporary files by the FileSystemCache
     _fs_transaction_suffix = ".__wz_cache"
     #: keep amount of files in a cache element
     _fs_count_file = "__wz_cache_count"
-    #: default file name hashing method
-    _default_hash_method = staticmethod(_lazy_md5)
 
     serializer = FileSystemSerializer()
 
@@ -59,15 +47,12 @@ class FileSystemCache(BaseCache):
         threshold: int = 500,
         default_timeout: int = 300,
         mode: int | None = None,
-        hash_method: _t.Any = None,
+        hash_method: _t.Any = hashlib.sha256,
     ):
         BaseCache.__init__(self, default_timeout)
         self._path = cache_dir
         self._threshold = threshold
-
-        self._hash_method = self._default_hash_method
-        if hash_method is not None:
-            self._hash_method = hash_method
+        self._hash_method = hash_method
 
         # Mode set by user takes precedence. If no mode has
         # been given, we need to set the correct default based

--- a/tests/test_file_system_cache.py
+++ b/tests/test_file_system_cache.py
@@ -46,20 +46,12 @@ class CustomHashingMethodCache(FileSystemCache):
         super().__init__(*args, hash_method=hashlib.sha256, **kwargs)
 
 
-class CustomDefaultHashingMethodCache(FileSystemCache):
-    _default_hash_method = hashlib.sha256
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
 @pytest.fixture(
     autouse=True,
     params=[
         FileSystemCache,
         CustomSerializerCache,
         CustomHashingMethodCache,
-        CustomDefaultHashingMethodCache,
     ],
 )
 def cache_factory(request, tmpdir):


### PR DESCRIPTION
fixes #500 