### PR TITLE
Add support for specifying timeouts as timedelta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,12 @@ Version 0.17.0
 
 Unreleased
 
-- A timeout now also accepts a ``datetime.timedelta`` in addition to int.
+- Timeout now also accepts a ``datetime.timedelta`` in addition to int. :pr:`510`
+- Float timeouts are deprecated and now rounded up to whole seconds, so
+  backends with integer-second APIs (e.g. memcached) no longer fail with
+  a confusing ``TypeError``. Passing a float will raise a ``TypeError``
+  in a future release; timeouts of any other unsupported type raise
+  ``TypeError`` immediately. :pr:`510`
 
 
 Version 0.16.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 0.17.0
+--------------
+
+Unreleased
+
+- A timeout now also accepts a ``datetime.timedelta`` in addition to int.
+
+
 Version 0.16.1
 ---------------
 

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -1,6 +1,5 @@
 from cachelib.base import BaseCache
 from cachelib.base import NullCache
-from cachelib.base import Timeout
 from cachelib.dynamodb import DynamoDbCache
 from cachelib.file import FileSystemCache
 from cachelib.memcached import MemcachedCache
@@ -21,6 +20,5 @@ __all__ = [
     "DynamoDbCache",
     "MongoDbCache",
     "ValkeyCache",
-    "Timeout",
 ]
 __version__ = "0.16.1"

--- a/src/cachelib/__init__.py
+++ b/src/cachelib/__init__.py
@@ -1,5 +1,6 @@
 from cachelib.base import BaseCache
 from cachelib.base import NullCache
+from cachelib.base import Timeout
 from cachelib.dynamodb import DynamoDbCache
 from cachelib.file import FileSystemCache
 from cachelib.memcached import MemcachedCache
@@ -20,5 +21,6 @@ __all__ = [
     "DynamoDbCache",
     "MongoDbCache",
     "ValkeyCache",
+    "Timeout",
 ]
 __version__ = "0.16.1"

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -1,13 +1,36 @@
+import datetime
+import math
 import typing as _t
+
+Timeout = int | datetime.timedelta
+
+
+def _to_seconds(timeout: Timeout) -> int:
+    """Convert a timeout to a whole number of seconds.
+
+    :param timeout: the timeout to convert. In case a
+                    :class:`datetime.timedelta` is passed it will round up
+                    subseconds to whole seconds (i.e. 200 milliseconds will
+                    will be rounded to 1 second)
+
+    .. versionadded:: 0.17.0
+    """
+    if isinstance(timeout, datetime.timedelta):
+        return math.ceil(timeout.total_seconds())
+    return timeout
 
 
 class BaseCache:
     """Base class for the cache systems.  All the cache systems implement this
     API or a superset of it.
 
-    :param default_timeout: the default timeout (in seconds) that is used if
-        no timeout is specified on :meth:`set`. A timeout
+    :param default_timeout: the default timeout that is used if
+        no timeout is specified on :meth:`set`. Either a number of seconds
+        or a :class:`datetime.timedelta`. A timeout
         of 0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
         exist are considered successfully deleted and do not raise.
@@ -16,15 +39,15 @@ class BaseCache:
     """
 
     def __init__(
-        self, default_timeout: int = 300, ignore_delete_many_errors: bool = True
+        self, default_timeout: Timeout = 300, ignore_delete_many_errors: bool = True
     ) -> None:
-        self.default_timeout = default_timeout
+        self.default_timeout = _to_seconds(default_timeout)
         self.ignore_delete_many_errors = ignore_delete_many_errors
 
-    def _normalize_timeout(self, timeout: int | None) -> int:
+    def _normalize_timeout(self, timeout: Timeout | None) -> int:
         if timeout is None:
             timeout = self.default_timeout
-        return timeout
+        return _to_seconds(timeout)
 
     def get(self, key: str) -> _t.Any:
         """Look up key in the cache and return the value for it.
@@ -67,13 +90,16 @@ class BaseCache:
         """
         return dict(zip(keys, self.get_many(*keys), strict=True))
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> bool | None:
+    def set(
+        self, key: str, value: _t.Any, timeout: Timeout | None = None
+    ) -> bool | None:
         """Add a new key/value to the cache (overwrites value, if key already
         exists in the cache).
 
         :param key: the key to set
         :param value: the value for the key
-        :param timeout: the cache timeout for the key in seconds (if not
+        :param timeout: the cache timeout for the key, either a number of
+            seconds or a :class:`datetime.timedelta` (if not
             specified, it uses the default timeout). A timeout of
             0 indicates that the cache never expires.
         :returns: ``True`` if key has been updated, ``False`` for backend
@@ -82,13 +108,14 @@ class BaseCache:
         """
         return True
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> bool:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
         """Works like :meth:`set` but does not overwrite the values of already
         existing keys.
 
         :param key: the key to set
         :param value: the value for the key
-        :param timeout: the cache timeout for the key in seconds (if not
+        :param timeout: the cache timeout for the key, either a number of
+            seconds or a :class:`datetime.timedelta` (if not
             specified, it uses the default timeout). A timeout of
             0 indicates that the cache never expires.
         :returns: Same as :meth:`set`, but also ``False`` for already
@@ -97,12 +124,13 @@ class BaseCache:
         return True
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: int | None = None
+        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
     ) -> list[_t.Any]:
         """Sets multiple keys and values from a mapping.
 
         :param mapping: a mapping with the keys/values to set.
-        :param timeout: the cache timeout for the key in seconds (if not
+        :param timeout: the cache timeout for the key, either a number of
+            seconds or a :class:`datetime.timedelta` (if not
             specified, it uses the default timeout). A timeout of
             0 indicates that the cache never expires.
         :returns: A list containing all keys successfully set

--- a/src/cachelib/base.py
+++ b/src/cachelib/base.py
@@ -1,23 +1,7 @@
-import datetime
+import datetime as dt
 import math
 import typing as _t
-
-Timeout = int | datetime.timedelta
-
-
-def _to_seconds(timeout: Timeout) -> int:
-    """Convert a timeout to a whole number of seconds.
-
-    :param timeout: the timeout to convert. In case a
-                    :class:`datetime.timedelta` is passed it will round up
-                    subseconds to whole seconds (i.e. 200 milliseconds will
-                    will be rounded to 1 second)
-
-    .. versionadded:: 0.17.0
-    """
-    if isinstance(timeout, datetime.timedelta):
-        return math.ceil(timeout.total_seconds())
-    return timeout
+import warnings
 
 
 class BaseCache:
@@ -39,15 +23,50 @@ class BaseCache:
     """
 
     def __init__(
-        self, default_timeout: Timeout = 300, ignore_delete_many_errors: bool = True
+        self,
+        default_timeout: int | dt.timedelta = 300,
+        ignore_delete_many_errors: bool = True,
     ) -> None:
-        self.default_timeout = _to_seconds(default_timeout)
+        self.default_timeout = self._to_seconds(default_timeout)
         self.ignore_delete_many_errors = ignore_delete_many_errors
 
-    def _normalize_timeout(self, timeout: Timeout | None) -> int:
+    @staticmethod
+    def _to_seconds(timeout: int | float | dt.timedelta) -> int:
+        """Convert a timeout to a whole number of seconds.
+
+        :param timeout: the timeout to convert. In case a
+            :class:`datetime.timedelta` is passed it will round up
+            subseconds to whole seconds (i.e. 200 milliseconds
+            will be rounded to 1 second)
+
+        .. versionadded:: 0.17.0
+
+        .. deprecated:: 0.17.0
+            Float timeouts are deprecated and rounded up to whole
+            seconds. They will raise a ``TypeError`` in a future release.
+        """
+        if isinstance(timeout, dt.timedelta):
+            return math.ceil(timeout.total_seconds())
+        if isinstance(timeout, float):
+            warnings.warn(
+                "Float timeouts are deprecated and will raise a TypeError"
+                " in a future release. Use a whole number of seconds or a"
+                " datetime.timedelta instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return math.ceil(timeout)
+        if isinstance(timeout, int):
+            return timeout
+        raise TypeError(
+            "timeout must be an int or datetime.timedelta, "
+            f"got {type(timeout).__name__!r}"
+        )
+
+    def _normalize_timeout(self, timeout: int | dt.timedelta | None) -> int:
         if timeout is None:
-            timeout = self.default_timeout
-        return _to_seconds(timeout)
+            return self.default_timeout
+        return self._to_seconds(timeout)
 
     def get(self, key: str) -> _t.Any:
         """Look up key in the cache and return the value for it.
@@ -91,7 +110,7 @@ class BaseCache:
         return dict(zip(keys, self.get_many(*keys), strict=True))
 
     def set(
-        self, key: str, value: _t.Any, timeout: Timeout | None = None
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
     ) -> bool | None:
         """Add a new key/value to the cache (overwrites value, if key already
         exists in the cache).
@@ -108,7 +127,9 @@ class BaseCache:
         """
         return True
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> bool:
         """Works like :meth:`set` but does not overwrite the values of already
         existing keys.
 
@@ -124,7 +145,7 @@ class BaseCache:
         return True
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
+        self, mapping: dict[str, _t.Any], timeout: int | dt.timedelta | None = None
     ) -> list[_t.Any]:
         """Sets multiple keys and values from a mapping.
 

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -2,6 +2,7 @@ import datetime
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import DynamoDbSerializer
 
 CREATED_AT_FIELD = "created_at"
@@ -26,8 +27,11 @@ class DynamoDbCache(BaseCache):
     time fields are also part of the item.
 
     :param table_name: The name of the DynamoDB table to use
-    :param default_timeout: Set the timeout in seconds after which cache entries
-        expire
+    :param default_timeout: Set the timeout after which cache entries expire,
+        either a number of seconds or a :class:`datetime.timedelta`
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_field: The name of the hash_key attribute in the DynamoDb
         table. This must be a string attribute.
     :param expiration_time_field: The name of the table attribute to store the
@@ -55,7 +59,7 @@ class DynamoDbCache(BaseCache):
     def __init__(
         self,
         table_name: str = "python-cache",
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_field: str = "cache_key",
         expiration_time_field: str = "expiration_time",
         key_prefix: str | None = None,
@@ -189,7 +193,7 @@ class DynamoDbCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: int | None = None,
+        timeout: Timeout | None = None,
         overwrite: bool | None = True,
     ) -> _t.Any:
         """
@@ -197,8 +201,9 @@ class DynamoDbCache(BaseCache):
 
         :param key: Cache key to use
         :param value: a serializable object
-        :param timeout: The timeout in seconds for the cached item, to override
-            the default
+        :param timeout: The timeout for the cached item, to override
+            the default. Either a number of seconds or a
+            :class:`datetime.timedelta`.
         :param overwrite: If true, overwrite any existing cache item with key.
             If false, the new value will only be stored if no
             non-expired cache item exists with key.
@@ -233,10 +238,10 @@ class DynamoDbCache(BaseCache):
         except Exception:
             return False
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         return self._set(self.key_prefix + key, value, timeout=timeout, overwrite=True)
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         return self._set(self.key_prefix + key, value, timeout=timeout, overwrite=False)
 
     def has(self, key: str) -> bool:

--- a/src/cachelib/dynamodb.py
+++ b/src/cachelib/dynamodb.py
@@ -1,8 +1,7 @@
-import datetime
+import datetime as dt
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import DynamoDbSerializer
 
 CREATED_AT_FIELD = "created_at"
@@ -59,7 +58,7 @@ class DynamoDbCache(BaseCache):
     def __init__(
         self,
         table_name: str = "python-cache",
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_field: str = "cache_key",
         expiration_time_field: str = "expiration_time",
         key_prefix: str | None = None,
@@ -124,9 +123,9 @@ class DynamoDbCache(BaseCache):
             self._table = self._dynamo.Table(table_name)
             self._table.load()
 
-    def _utcnow(self) -> datetime.datetime:
+    def _utcnow(self) -> dt.datetime:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.now(datetime.UTC)
+        return dt.datetime.now(dt.UTC)
 
     def _get_item(self, key: str, attributes: list[_t.Any] | None = None) -> _t.Any:
         """
@@ -193,7 +192,7 @@ class DynamoDbCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: Timeout | None = None,
+        timeout: int | dt.timedelta | None = None,
         overwrite: bool | None = True,
     ) -> _t.Any:
         """
@@ -209,7 +208,7 @@ class DynamoDbCache(BaseCache):
             non-expired cache item exists with key.
         :return: True if the new item was stored.
         """
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         now = self._utcnow()
 
         try:
@@ -219,8 +218,8 @@ class DynamoDbCache(BaseCache):
                 CREATED_AT_FIELD: now.isoformat(),
                 RESPONSE_FIELD: dump,
             }
-            if timeout > 0:
-                expiration_time = now + datetime.timedelta(seconds=timeout)
+            if normalized_timeout > 0:
+                expiration_time = now + dt.timedelta(seconds=normalized_timeout)
                 item[self._expiration_time_field] = int(expiration_time.timestamp())
 
             kwargs: PutItemInputTablePutItemTypeDef = {"Item": item}
@@ -238,10 +237,14 @@ class DynamoDbCache(BaseCache):
         except Exception:
             return False
 
-    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
+    def set(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
         return self._set(self.key_prefix + key, value, timeout=timeout, overwrite=True)
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
         return self._set(self.key_prefix + key, value, timeout=timeout, overwrite=False)
 
     def has(self, key: str) -> bool:

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import errno
 import hashlib
 import logging
@@ -13,7 +14,6 @@ from time import sleep
 from time import time
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import FileSystemSerializer
 
 
@@ -55,7 +55,7 @@ class FileSystemCache(BaseCache):
         self,
         cache_dir: str,
         threshold: int = 500,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         mode: int | None = None,
         hash_method: _t.Any = hashlib.sha256,
         ignore_delete_many_errors: bool = True,
@@ -105,11 +105,11 @@ class FileSystemCache(BaseCache):
             new_count = value or 0
         self.set(self._fs_count_file, new_count, mgmt_element=True)
 
-    def _normalize_timeout(self, timeout: Timeout | None) -> int:
-        seconds = BaseCache._normalize_timeout(self, timeout)
-        if seconds != 0:
-            seconds = int(time()) + seconds
-        return int(seconds)
+    def _normalize_timeout(self, timeout: int | dt.timedelta | None) -> int:
+        normalized_timeout = BaseCache._normalize_timeout(self, timeout)
+        if normalized_timeout != 0:
+            normalized_timeout = int(time()) + normalized_timeout
+        return int(normalized_timeout)
 
     def _is_mgmt(self, name: str) -> bool:
         fshash = self._get_filename(self._fs_count_file).split(os.sep)[-1]
@@ -228,7 +228,9 @@ class FileSystemCache(BaseCache):
             )
         return None
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> bool:
         filename = self._get_filename(key)
         if not os.path.exists(filename):
             return self.set(key, value, timeout)
@@ -238,7 +240,7 @@ class FileSystemCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: Timeout | None = None,
+        timeout: int | dt.timedelta | None = None,
         mgmt_element: bool = False,
     ) -> bool:
         # Management elements have no timeout
@@ -248,7 +250,7 @@ class FileSystemCache(BaseCache):
         else:
             self._prune()
 
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         filename = self._get_filename(key)
         overwrite = os.path.isfile(filename)
 
@@ -257,7 +259,7 @@ class FileSystemCache(BaseCache):
                 suffix=self._fs_transaction_suffix, dir=self._path
             )
             with os.fdopen(fd, "wb") as f:
-                f.write(struct.pack("I", timeout))
+                f.write(struct.pack("I", normalized_timeout))
                 self.serializer.dump(value, f)
 
             self._run_safely(os.replace, tmp, filename)

--- a/src/cachelib/file.py
+++ b/src/cachelib/file.py
@@ -13,6 +13,7 @@ from time import sleep
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import FileSystemSerializer
 
 
@@ -27,8 +28,12 @@ class FileSystemCache(BaseCache):
         it starts deleting some. A threshold value of 0
         indicates no threshold.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param mode: the file mode wanted for the cache files, default 0600
     :param hash_method: Default :func:`~hashlib.sha256`. The hash method used to
         generate the filename for cached results.
@@ -50,7 +55,7 @@ class FileSystemCache(BaseCache):
         self,
         cache_dir: str,
         threshold: int = 500,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         mode: int | None = None,
         hash_method: _t.Any = hashlib.sha256,
         ignore_delete_many_errors: bool = True,
@@ -100,11 +105,11 @@ class FileSystemCache(BaseCache):
             new_count = value or 0
         self.set(self._fs_count_file, new_count, mgmt_element=True)
 
-    def _normalize_timeout(self, timeout: int | None) -> int:
-        timeout = BaseCache._normalize_timeout(self, timeout)
-        if timeout != 0:
-            timeout = int(time()) + timeout
-        return int(timeout)
+    def _normalize_timeout(self, timeout: Timeout | None) -> int:
+        seconds = BaseCache._normalize_timeout(self, timeout)
+        if seconds != 0:
+            seconds = int(time()) + seconds
+        return int(seconds)
 
     def _is_mgmt(self, name: str) -> bool:
         fshash = self._get_filename(self._fs_count_file).split(os.sep)[-1]
@@ -223,7 +228,7 @@ class FileSystemCache(BaseCache):
             )
         return None
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> bool:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
         filename = self._get_filename(key)
         if not os.path.exists(filename):
             return self.set(key, value, timeout)
@@ -233,7 +238,7 @@ class FileSystemCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: int | None = None,
+        timeout: Timeout | None = None,
         mgmt_element: bool = False,
     ) -> bool:
         # Management elements have no timeout

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -6,6 +6,7 @@ from functools import partial
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 
 _test_memcached_key = re.compile(r"[^\x00-\x21\xff]{1,250}$").match
 
@@ -39,8 +40,12 @@ class MemcachedCache(BaseCache):
     :param servers: a list or tuple of server addresses or alternatively
         a ``memcache.Client`` or a compatible client.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_prefix: a prefix that is added before all keys.  This makes it
         possible to use the same memcached server for different
         applications.  Keep in mind that
@@ -72,7 +77,7 @@ class MemcachedCache(BaseCache):
     def __init__(
         self,
         servers: _t.Any = None,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_prefix: str | None = None,
         pool_size: int = 1,
         pool_blocking: bool = True,
@@ -107,11 +112,11 @@ class MemcachedCache(BaseCache):
             key = self.key_prefix + key
         return key
 
-    def _normalize_timeout(self, timeout: int | None) -> int:
-        timeout = BaseCache._normalize_timeout(self, timeout)
-        if timeout > 0:
-            timeout = int(time()) + timeout
-        return timeout
+    def _normalize_timeout(self, timeout: Timeout | None) -> int:
+        seconds = BaseCache._normalize_timeout(self, timeout)
+        if seconds > 0:
+            seconds = int(time()) + seconds
+        return seconds
 
     def get(self, key: str) -> _t.Any:
         key = self._normalize_key(key)
@@ -142,13 +147,15 @@ class MemcachedCache(BaseCache):
                     rv[key] = None
         return rv
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> bool:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
         key = self._normalize_key(key)
         timeout = self._normalize_timeout(timeout)
         with self._client_context() as client:
             return bool(client.add(key, value, timeout))
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> bool | None:
+    def set(
+        self, key: str, value: _t.Any, timeout: Timeout | None = None
+    ) -> bool | None:
         key = self._normalize_key(key)
         timeout = self._normalize_timeout(timeout)
         with self._client_context() as client:
@@ -159,7 +166,7 @@ class MemcachedCache(BaseCache):
         return [d[key] for key in keys]
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: int | None = None
+        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
     ) -> list[_t.Any]:
         new_mapping = {}
         for key, value in mapping.items():

--- a/src/cachelib/memcached.py
+++ b/src/cachelib/memcached.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import re
 import typing as _t
 from contextlib import contextmanager
@@ -6,7 +7,6 @@ from functools import partial
 from time import time
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 
 _test_memcached_key = re.compile(r"[^\x00-\x21\xff]{1,250}$").match
 
@@ -77,7 +77,7 @@ class MemcachedCache(BaseCache):
     def __init__(
         self,
         servers: _t.Any = None,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_prefix: str | None = None,
         pool_size: int = 1,
         pool_blocking: bool = True,
@@ -112,11 +112,11 @@ class MemcachedCache(BaseCache):
             key = self.key_prefix + key
         return key
 
-    def _normalize_timeout(self, timeout: Timeout | None) -> int:
-        seconds = BaseCache._normalize_timeout(self, timeout)
-        if seconds > 0:
-            seconds = int(time()) + seconds
-        return seconds
+    def _normalize_timeout(self, timeout: int | dt.timedelta | None) -> int:
+        normalized_timeout = BaseCache._normalize_timeout(self, timeout)
+        if normalized_timeout > 0:
+            normalized_timeout = int(time()) + normalized_timeout
+        return normalized_timeout
 
     def get(self, key: str) -> _t.Any:
         key = self._normalize_key(key)
@@ -147,43 +147,47 @@ class MemcachedCache(BaseCache):
                     rv[key] = None
         return rv
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
-        key = self._normalize_key(key)
-        timeout = self._normalize_timeout(timeout)
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> bool:
+        normalized_key = self._normalize_key(key)
+        normalized_timeout = self._normalize_timeout(timeout)
         with self._client_context() as client:
-            return bool(client.add(key, value, timeout))
+            return bool(client.add(normalized_key, value, normalized_timeout))
 
     def set(
-        self, key: str, value: _t.Any, timeout: Timeout | None = None
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
     ) -> bool | None:
-        key = self._normalize_key(key)
-        timeout = self._normalize_timeout(timeout)
+        normalized_key = self._normalize_key(key)
+        normalized_timeout = self._normalize_timeout(timeout)
         with self._client_context() as client:
-            return bool(client.set(key, value, timeout))
+            return bool(client.set(normalized_key, value, normalized_timeout))
 
     def get_many(self, *keys: str) -> list[_t.Any]:
         d = self.get_dict(*keys)
         return [d[key] for key in keys]
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
+        self, mapping: dict[str, _t.Any], timeout: int | dt.timedelta | None = None
     ) -> list[_t.Any]:
         new_mapping = {}
         for key, value in mapping.items():
             key = self._normalize_key(key)
             new_mapping[key] = value
 
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         with self._client_context() as client:
-            failed_keys: list[_t.Any] = client.set_multi(new_mapping, timeout)
+            failed_keys: list[_t.Any] = client.set_multi(
+                new_mapping, normalized_timeout
+            )
         k_normkey = zip(mapping.keys(), new_mapping.keys(), strict=True)
         return [k for k, nkey in k_normkey if nkey not in failed_keys]
 
     def delete(self, key: str) -> bool:
-        key = self._normalize_key(key)
-        if _test_memcached_key(key):
+        normalized_key = self._normalize_key(key)
+        if _test_memcached_key(normalized_key):
             with self._client_context() as client:
-                return bool(client.delete(key))
+                return bool(client.delete(normalized_key))
         return False
 
     def delete_many(self, *keys: str) -> list[_t.Any]:
@@ -204,10 +208,10 @@ class MemcachedCache(BaseCache):
         return deleted_keys
 
     def has(self, key: str) -> bool:
-        key = self._normalize_key(key)
-        if _test_memcached_key(key):
+        normalized_key = self._normalize_key(key)
+        if _test_memcached_key(normalized_key):
             with self._client_context() as client:
-                return bool(client.append(key, ""))
+                return bool(client.append(normalized_key, ""))
         return False
 
     def clear(self) -> bool:

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -1,8 +1,7 @@
-import datetime
+import datetime as dt
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import MongoDbSerializer
 
 
@@ -42,7 +41,7 @@ class MongoDbCache(BaseCache):
         client: _t.Any = None,
         db: str = "cache-db",
         collection: str = "cache-collection",
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_prefix: str | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -76,9 +75,9 @@ class MongoDbCache(BaseCache):
         self.key_prefix = key_prefix or ""
         self.collection = collection
 
-    def _utcnow(self) -> datetime.datetime:
+    def _utcnow(self) -> dt.datetime:
         """Return a tz-aware UTC datetime representing the current time"""
-        return datetime.datetime.now(datetime.UTC)
+        return dt.datetime.now(dt.UTC)
 
     def _expire_records(self) -> _t.Any:
         res = self.client.delete_many({"expiration": {"$lte": self._utcnow()}})
@@ -114,7 +113,7 @@ class MongoDbCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: Timeout | None = None,
+        timeout: int | dt.timedelta | None = None,
         overwrite: bool | None = True,
     ) -> _t.Any:
         """
@@ -130,7 +129,7 @@ class MongoDbCache(BaseCache):
             non-expired cache item exists with key.
         :return: True if the new item was stored.
         """
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         now = self._utcnow()
 
         if not overwrite:
@@ -140,39 +139,41 @@ class MongoDbCache(BaseCache):
                 return False
 
         dump = self.serializer.dumps(value)
-        record: dict[str, str | bytes | None | datetime.datetime] = {
+        record: dict[str, str | bytes | None | dt.datetime] = {
             "id": self.key_prefix + key,
             "val": dump,
         }
 
-        if timeout > 0:
-            record["expiration"] = now + datetime.timedelta(seconds=timeout)
+        if normalized_timeout > 0:
+            record["expiration"] = now + dt.timedelta(seconds=normalized_timeout)
         self.client.update_one({"id": self.key_prefix + key}, {"$set": record}, True)
         return True
 
-    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
+    def set(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
         self._expire_records()
         return self._set(key, value, timeout=timeout, overwrite=True)
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
+        self, mapping: dict[str, _t.Any], timeout: int | dt.timedelta | None = None
     ) -> list[_t.Any]:
         self._expire_records()
         from pymongo import UpdateOne
 
         operations = []
         now = self._utcnow()
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         for key, val in mapping.items():
             dump = self.serializer.dumps(val)
 
-            record: dict[str, str | bytes | None | datetime.datetime] = {
+            record: dict[str, str | bytes | None | dt.datetime] = {
                 "id": self.key_prefix + key,
                 "val": dump,
             }
 
-            if timeout > 0:
-                record["expiration"] = now + datetime.timedelta(seconds=timeout)
+            if normalized_timeout > 0:
+                record["expiration"] = now + dt.timedelta(seconds=normalized_timeout)
             operations.append(
                 UpdateOne({"id": self.key_prefix + key}, {"$set": record}, upsert=True),
             )
@@ -206,7 +207,9 @@ class MongoDbCache(BaseCache):
             results[item["id"][len(self.key_prefix) :]] = value
         return results
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
         self._expire_records()
         return self._set(key, value, timeout=timeout, overwrite=False)
 

--- a/src/cachelib/mongodb.py
+++ b/src/cachelib/mongodb.py
@@ -2,6 +2,7 @@ import datetime
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import MongoDbSerializer
 
 
@@ -15,8 +16,11 @@ class MongoDbCache(BaseCache):
     :param client: mongodb client or connection string
     :param db: mongodb database name
     :param collection: mongodb collection name
-    :param default_timeout: Set the timeout in seconds after which cache entries
-        expire
+    :param default_timeout: Set the timeout after which cache entries expire,
+        either a number of seconds or a :class:`datetime.timedelta`
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_prefix: A prefix that should be added to all keys.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
@@ -38,7 +42,7 @@ class MongoDbCache(BaseCache):
         client: _t.Any = None,
         db: str = "cache-db",
         collection: str = "cache-collection",
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_prefix: str | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -110,7 +114,7 @@ class MongoDbCache(BaseCache):
         self,
         key: str,
         value: _t.Any,
-        timeout: int | None = None,
+        timeout: Timeout | None = None,
         overwrite: bool | None = True,
     ) -> _t.Any:
         """
@@ -118,8 +122,9 @@ class MongoDbCache(BaseCache):
 
         :param key: Cache key to use
         :param value: a serializable object
-        :param timeout: The timeout in seconds for the cached item, to override
-            the default
+        :param timeout: The timeout for the cached item, to override
+            the default. Either a number of seconds or a
+            :class:`datetime.timedelta`.
         :param overwrite: If true, overwrite any existing cache item with key.
             If false, the new value will only be stored if no
             non-expired cache item exists with key.
@@ -145,12 +150,12 @@ class MongoDbCache(BaseCache):
         self.client.update_one({"id": self.key_prefix + key}, {"$set": record}, True)
         return True
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         self._expire_records()
         return self._set(key, value, timeout=timeout, overwrite=True)
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: int | None = None
+        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
     ) -> list[_t.Any]:
         self._expire_records()
         from pymongo import UpdateOne
@@ -201,7 +206,7 @@ class MongoDbCache(BaseCache):
             results[item["id"][len(self.key_prefix) :]] = value
         return results
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         self._expire_records()
         return self._set(key, value, timeout=timeout, overwrite=False)
 

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -1,5 +1,6 @@
 import typing as _t
 
+from cachelib.base import Timeout
 from cachelib.redis_base import BaseRedisCache
 from cachelib.serializers import RedisSerializer
 
@@ -19,8 +20,12 @@ class RedisCache(BaseRedisCache):
     :param password: password authentication for the Redis server.
     :param db: db (zero-based numeric index) on Redis Server to connect.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_prefix: A prefix that should be added to all keys.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
@@ -46,7 +51,7 @@ class RedisCache(BaseRedisCache):
         port: int = 6379,
         password: str | None = None,
         db: int = 0,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,

--- a/src/cachelib/redis.py
+++ b/src/cachelib/redis.py
@@ -1,6 +1,6 @@
+import datetime as dt
 import typing as _t
 
-from cachelib.base import Timeout
 from cachelib.redis_base import BaseRedisCache
 from cachelib.serializers import RedisSerializer
 
@@ -51,7 +51,7 @@ class RedisCache(BaseRedisCache):
         port: int = 6379,
         password: str | None = None,
         db: int = 0,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,

--- a/src/cachelib/redis_base.py
+++ b/src/cachelib/redis_base.py
@@ -1,6 +1,7 @@
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import BaseRedisSerializer
 
 
@@ -12,8 +13,12 @@ class BaseRedisCache(BaseCache):
 
     :param client: a connected client instance compatible with the Redis API.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_prefix: A prefix that should be added to all keys.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
@@ -35,7 +40,7 @@ class BaseRedisCache(BaseCache):
     def __init__(
         self,
         client: _t.Any,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -52,16 +57,17 @@ class BaseRedisCache(BaseCache):
             self.key_prefix if isinstance(self.key_prefix, str) else self.key_prefix()
         )
 
-    def _normalize_timeout(self, timeout: int | None) -> int:
+    def _normalize_timeout(self, timeout: Timeout | None) -> int:
         """Normalize timeout by setting it to default of 300 if
         not defined (None) or -1 if explicitly set to zero.
 
-        :param timeout: timeout to normalize.
+        :param timeout: timeout to normalize, either a number of seconds
+            or a :class:`datetime.timedelta`.
         """
-        timeout = BaseCache._normalize_timeout(self, timeout)
-        if timeout == 0:
-            timeout = -1
-        return timeout
+        seconds = BaseCache._normalize_timeout(self, timeout)
+        if seconds == 0:
+            seconds = -1
+        return seconds
 
     def get(self, key: str) -> _t.Any:
         return self.serializer.loads(
@@ -75,7 +81,7 @@ class BaseRedisCache(BaseCache):
             prefixed_keys = list(keys)
         return [self.serializer.loads(x) for x in self._read_client.mget(prefixed_keys)]
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         timeout = self._normalize_timeout(timeout)
         dump = self.serializer.dumps(value)
         result = self._write_client.set(
@@ -85,7 +91,7 @@ class BaseRedisCache(BaseCache):
         )
         return result
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> _t.Any:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
         timeout = self._normalize_timeout(timeout)
         dump = self.serializer.dumps(value)
         created = self._write_client.setnx(
@@ -97,7 +103,7 @@ class BaseRedisCache(BaseCache):
         return created
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: int | None = None
+        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
     ) -> list[_t.Any]:
         timeout = self._normalize_timeout(timeout)
         # Use transaction=False to batch without calling redis MULTI

--- a/src/cachelib/redis_base.py
+++ b/src/cachelib/redis_base.py
@@ -1,7 +1,7 @@
+import datetime as dt
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import BaseRedisSerializer
 
 
@@ -40,7 +40,7 @@ class BaseRedisCache(BaseCache):
     def __init__(
         self,
         client: _t.Any,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -57,17 +57,17 @@ class BaseRedisCache(BaseCache):
             self.key_prefix if isinstance(self.key_prefix, str) else self.key_prefix()
         )
 
-    def _normalize_timeout(self, timeout: Timeout | None) -> int:
+    def _normalize_timeout(self, timeout: int | dt.timedelta | None) -> int:
         """Normalize timeout by setting it to default of 300 if
         not defined (None) or -1 if explicitly set to zero.
 
         :param timeout: timeout to normalize, either a number of seconds
             or a :class:`datetime.timedelta`.
         """
-        seconds = BaseCache._normalize_timeout(self, timeout)
-        if seconds == 0:
-            seconds = -1
-        return seconds
+        normalized_timeout = BaseCache._normalize_timeout(self, timeout)
+        if normalized_timeout == 0:
+            normalized_timeout = -1
+        return normalized_timeout
 
     def get(self, key: str) -> _t.Any:
         return self.serializer.loads(
@@ -81,31 +81,37 @@ class BaseRedisCache(BaseCache):
             prefixed_keys = list(keys)
         return [self.serializer.loads(x) for x in self._read_client.mget(prefixed_keys)]
 
-    def set(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
-        timeout = self._normalize_timeout(timeout)
+    def set(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
+        normalized_timeout = self._normalize_timeout(timeout)
         dump = self.serializer.dumps(value)
         result = self._write_client.set(
             name=f"{self._get_prefix()}{key}",
             value=dump,
-            ex=timeout if timeout != -1 else None,
+            ex=normalized_timeout if normalized_timeout != -1 else None,
         )
         return result
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> _t.Any:
-        timeout = self._normalize_timeout(timeout)
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> _t.Any:
+        normalized_timeout = self._normalize_timeout(timeout)
         dump = self.serializer.dumps(value)
         created = self._write_client.setnx(
             name=f"{self._get_prefix()}{key}", value=dump
         )
         # handle case where timeout is explicitly set to zero
-        if created and timeout != -1:
-            self._write_client.expire(name=f"{self._get_prefix()}{key}", time=timeout)
+        if created and normalized_timeout != -1:
+            self._write_client.expire(
+                name=f"{self._get_prefix()}{key}", time=normalized_timeout
+            )
         return created
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
+        self, mapping: dict[str, _t.Any], timeout: int | dt.timedelta | None = None
     ) -> list[_t.Any]:
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         # Use transaction=False to batch without calling redis MULTI
         # which is not supported by twemproxy
         pipe = self._write_client.pipeline(transaction=False)
@@ -115,7 +121,7 @@ class BaseRedisCache(BaseCache):
             pipe.set(
                 name=f"{self._get_prefix()}{key}",
                 value=dump,
-                ex=timeout if timeout != -1 else None,
+                ex=normalized_timeout if normalized_timeout != -1 else None,
             )
         results = pipe.execute()
         return [

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -1,9 +1,9 @@
+import datetime as dt
 import threading
 import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import SimpleSerializer
 
 
@@ -33,7 +33,7 @@ class SimpleCache(BaseCache):
     def __init__(
         self,
         threshold: int = 500,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         ignore_delete_many_errors: bool = True,
     ):
         BaseCache.__init__(
@@ -68,11 +68,11 @@ class SimpleCache(BaseCache):
         if self._over_threshold():
             self._remove_older()
 
-    def _normalize_timeout(self, timeout: Timeout | None) -> int:
-        seconds = BaseCache._normalize_timeout(self, timeout)
-        if seconds > 0:
-            seconds = int(time()) + seconds
-        return seconds
+    def _normalize_timeout(self, timeout: int | dt.timedelta | None) -> int:
+        normalized_timeout = BaseCache._normalize_timeout(self, timeout)
+        if normalized_timeout > 0:
+            normalized_timeout = int(time()) + normalized_timeout
+        return normalized_timeout
 
     def get(self, key: str) -> _t.Any:
         with self._lock:
@@ -84,7 +84,7 @@ class SimpleCache(BaseCache):
                 return None
 
     def set(
-        self, key: str, value: _t.Any, timeout: Timeout | None = None
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
     ) -> bool | None:
         with self._lock:
             expires = self._normalize_timeout(timeout)
@@ -92,7 +92,9 @@ class SimpleCache(BaseCache):
             self._cache[key] = (expires, self.serializer.dumps(value))
             return True
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> bool:
         with self._lock:
             expires = self._normalize_timeout(timeout)
             self._prune()

--- a/src/cachelib/simple.py
+++ b/src/cachelib/simple.py
@@ -3,6 +3,7 @@ import typing as _t
 from time import time
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import SimpleSerializer
 
 
@@ -14,8 +15,12 @@ class SimpleCache(BaseCache):
     :param threshold: the maximum number of items the cache stores before
         it starts deleting some.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
         exist are considered successfully deleted and do not raise.
@@ -28,7 +33,7 @@ class SimpleCache(BaseCache):
     def __init__(
         self,
         threshold: int = 500,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         ignore_delete_many_errors: bool = True,
     ):
         BaseCache.__init__(
@@ -63,11 +68,11 @@ class SimpleCache(BaseCache):
         if self._over_threshold():
             self._remove_older()
 
-    def _normalize_timeout(self, timeout: int | None) -> int:
-        timeout = BaseCache._normalize_timeout(self, timeout)
-        if timeout > 0:
-            timeout = int(time()) + timeout
-        return timeout
+    def _normalize_timeout(self, timeout: Timeout | None) -> int:
+        seconds = BaseCache._normalize_timeout(self, timeout)
+        if seconds > 0:
+            seconds = int(time()) + seconds
+        return seconds
 
     def get(self, key: str) -> _t.Any:
         with self._lock:
@@ -78,14 +83,16 @@ class SimpleCache(BaseCache):
             except KeyError:
                 return None
 
-    def set(self, key: str, value: _t.Any, timeout: int | None = None) -> bool | None:
+    def set(
+        self, key: str, value: _t.Any, timeout: Timeout | None = None
+    ) -> bool | None:
         with self._lock:
             expires = self._normalize_timeout(timeout)
             self._prune()
             self._cache[key] = (expires, self.serializer.dumps(value))
             return True
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> bool:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
         with self._lock:
             expires = self._normalize_timeout(timeout)
             self._prune()

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -2,6 +2,7 @@ import platform
 import typing as _t
 
 from cachelib.base import BaseCache
+from cachelib.base import Timeout
 from cachelib.serializers import UWSGISerializer
 
 
@@ -12,7 +13,11 @@ class UWSGICache(BaseCache):
         This class cannot be used when running under PyPy, because the uWSGI
         API implementation for PyPy is lacking the needed functionality.
 
-    :param default_timeout: The default timeout in seconds.
+    :param default_timeout: The default timeout, either a number of seconds
+        or a :class:`datetime.timedelta`.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param cache: The name of the caching instance to connect to, for
         example: mycache@localhost:3031, defaults to an empty string, which
         means uWSGI will cache in the local instance. If the cache is in the
@@ -29,7 +34,7 @@ class UWSGICache(BaseCache):
 
     def __init__(
         self,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         cache: str = "",
         ignore_delete_many_errors: bool = True,
     ):
@@ -63,7 +68,7 @@ class UWSGICache(BaseCache):
         return bool(self._uwsgi.cache_del(key, self.cache))
 
     def set(
-        self, key: str, value: _t.Any, timeout: int | None = None
+        self, key: str, value: _t.Any, timeout: Timeout | None = None
     ) -> _t.Literal[True] | None:
         result = self._uwsgi.cache_update(
             key,
@@ -73,7 +78,7 @@ class UWSGICache(BaseCache):
         )  # type: _t.Optional[_t.Literal[True]]
         return result
 
-    def add(self, key: str, value: _t.Any, timeout: int | None = None) -> bool:
+    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
         return bool(
             self._uwsgi.cache_set(
                 key,

--- a/src/cachelib/uwsgi.py
+++ b/src/cachelib/uwsgi.py
@@ -1,8 +1,8 @@
+import datetime as dt
 import platform
 import typing as _t
 
 from cachelib.base import BaseCache
-from cachelib.base import Timeout
 from cachelib.serializers import UWSGISerializer
 
 
@@ -34,7 +34,7 @@ class UWSGICache(BaseCache):
 
     def __init__(
         self,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         cache: str = "",
         ignore_delete_many_errors: bool = True,
     ):
@@ -68,7 +68,7 @@ class UWSGICache(BaseCache):
         return bool(self._uwsgi.cache_del(key, self.cache))
 
     def set(
-        self, key: str, value: _t.Any, timeout: Timeout | None = None
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
     ) -> _t.Literal[True] | None:
         result = self._uwsgi.cache_update(
             key,
@@ -78,7 +78,9 @@ class UWSGICache(BaseCache):
         )  # type: _t.Optional[_t.Literal[True]]
         return result
 
-    def add(self, key: str, value: _t.Any, timeout: Timeout | None = None) -> bool:
+    def add(
+        self, key: str, value: _t.Any, timeout: int | dt.timedelta | None = None
+    ) -> bool:
         return bool(
             self._uwsgi.cache_set(
                 key,

--- a/src/cachelib/valkey.py
+++ b/src/cachelib/valkey.py
@@ -1,5 +1,6 @@
 import typing as _t
 
+from cachelib.base import Timeout
 from cachelib.redis_base import BaseRedisCache
 from cachelib.serializers import ValkeySerializer
 
@@ -19,8 +20,12 @@ class ValkeyCache(BaseRedisCache):
     :param password: password authentication for the Valkey server.
     :param db: db (zero-based numeric index) on Valkey Server to connect.
     :param default_timeout: the default timeout that is used if no timeout is
-        specified on :meth:`~.BaseCache.set`. A timeout of
+        specified on :meth:`~.BaseCache.set`. Either a number of seconds or a
+        :class:`datetime.timedelta`. A timeout of
         0 indicates that the cache never expires.
+
+        .. versionchanged:: 0.17.0
+            Accepts a :class:`datetime.timedelta`.
     :param key_prefix: A prefix that should be added to all keys.
     :param ignore_delete_many_errors: If False, delete_many() will raise
         a RuntimeError if any key fails to delete. Keys that do not
@@ -45,7 +50,7 @@ class ValkeyCache(BaseRedisCache):
         port: int = 6379,
         password: str | None = None,
         db: int = 0,
-        default_timeout: int = 300,
+        default_timeout: Timeout = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -81,7 +86,7 @@ class ValkeyCache(BaseRedisCache):
         )
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: int | None = None
+        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
     ) -> list[_t.Any]:
         timeout = self._normalize_timeout(timeout)
         # Use transaction=False to batch without calling MULTI

--- a/src/cachelib/valkey.py
+++ b/src/cachelib/valkey.py
@@ -1,6 +1,6 @@
+import datetime as dt
 import typing as _t
 
-from cachelib.base import Timeout
 from cachelib.redis_base import BaseRedisCache
 from cachelib.serializers import ValkeySerializer
 
@@ -50,7 +50,7 @@ class ValkeyCache(BaseRedisCache):
         port: int = 6379,
         password: str | None = None,
         db: int = 0,
-        default_timeout: Timeout = 300,
+        default_timeout: int | dt.timedelta = 300,
         key_prefix: str | _t.Callable[[], str] | None = None,
         ignore_delete_many_errors: bool = True,
         check_connection: bool = False,
@@ -86,9 +86,9 @@ class ValkeyCache(BaseRedisCache):
         )
 
     def set_many(
-        self, mapping: dict[str, _t.Any], timeout: Timeout | None = None
+        self, mapping: dict[str, _t.Any], timeout: int | dt.timedelta | None = None
     ) -> list[_t.Any]:
-        timeout = self._normalize_timeout(timeout)
+        normalized_timeout = self._normalize_timeout(timeout)
         # Use transaction=False to batch without calling MULTI
         pipe = self._write_client.pipeline(transaction=False)
 
@@ -97,7 +97,7 @@ class ValkeyCache(BaseRedisCache):
             pipe.set(
                 name=f"{self._get_prefix()}{key}",
                 value=dump,
-                ex=timeout if timeout != -1 else None,
+                ex=normalized_timeout if normalized_timeout != -1 else None,
             )
         results = pipe.execute()
         return [

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 from time import sleep
 
 import pytest
-
-from conftest import TestData, under_uwsgi
+from conftest import TestData
+from conftest import under_uwsgi
 
 
 class CommonTests(TestData):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,8 +1,9 @@
+from datetime import timedelta
 from time import sleep
 
 import pytest
-from conftest import TestData
-from conftest import under_uwsgi
+
+from conftest import TestData, under_uwsgi
 
 
 class CommonTests(TestData):
@@ -101,7 +102,12 @@ class CommonTests(TestData):
         for k, v in self.sample_pairs.items():
             cache.set(f"{k}-t0", v, timeout=0)
             cache.set(f"{k}-t1", v, timeout=1)
+            # timedeltas are equivalent to the same amount of seconds
+            cache.set(f"{k}-td0", v, timeout=timedelta())
+            cache.set(f"{k}-td1", v, timeout=timedelta(seconds=1))
         sleep(4)
         for k, v in self.sample_pairs.items():
             assert cache.get(f"{k}-t0") == v
             assert not cache.get(f"{k}-t1")
+            assert cache.get(f"{k}-td0") == v
+            assert not cache.get(f"{k}-td1")

--- a/tests/test_base_cache.py
+++ b/tests/test_base_cache.py
@@ -111,3 +111,26 @@ class TestBaseCache:
     def test_default_timeout_timedelta_is_stored_as_seconds(self):
         cache = BaseCache(default_timeout=timedelta(minutes=5))
         assert cache.default_timeout == 300
+
+    @pytest.mark.parametrize(
+        "input_timeout,expected",
+        [
+            (0.1, 1),  # subsecond floats round up, not down to "never expires"
+            (5.0, 5),
+            (5.5, 6),
+        ],
+    )
+    def test_float_timeout_is_deprecated_and_rounded_up(self, input_timeout, expected):
+        cache = self.cache_factory()
+        with pytest.warns(DeprecationWarning, match="Float timeouts are deprecated"):
+            assert cache._normalize_timeout(input_timeout) == expected
+
+    def test_float_default_timeout_is_deprecated(self):
+        with pytest.warns(DeprecationWarning, match="Float timeouts are deprecated"):
+            cache = BaseCache(default_timeout=1.5)
+        assert cache.default_timeout == 2
+
+    def test_invalid_timeout_type_raises(self):
+        cache = self.cache_factory()
+        with pytest.raises(TypeError, match="timeout must be an int"):
+            cache._normalize_timeout("60")

--- a/tests/test_base_cache.py
+++ b/tests/test_base_cache.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+
 from cachelib import BaseCache
 
 

--- a/tests/test_base_cache.py
+++ b/tests/test_base_cache.py
@@ -1,5 +1,6 @@
-import pytest
+from datetime import timedelta
 
+import pytest
 from cachelib import BaseCache
 
 
@@ -92,8 +93,20 @@ class TestBaseCache:
             (300, 0, 0),  # explicit zero stays zero (permanent)
             (300, 60, 60),  # explicit value is returned as-is
             (0, None, 0),  # default_timeout=0 means permanently cached by default
+            (300, timedelta(seconds=60), 60),  # timedelta is converted to seconds
+            (300, timedelta(minutes=2), 120),
+            (300, timedelta(days=1), 86400),
+            (300, timedelta(), 0),  # a zero timedelta is permanent, like 0
+            (300, timedelta(milliseconds=500), 1),  # sub-second timeouts round up
+            (300, timedelta(seconds=1, milliseconds=200), 2),
+            (timedelta(minutes=1), None, 60),  # timedelta default
+            (timedelta(minutes=1), 30, 30),  # explicit value beats timedelta default
         ],
     )
     def test_normalize_timeout(self, default_timeout, input_timeout, expected):
         cache = BaseCache(default_timeout=default_timeout)
         assert cache._normalize_timeout(input_timeout) == expected
+
+    def test_default_timeout_timedelta_is_stored_as_seconds(self):
+        cache = BaseCache(default_timeout=timedelta(minutes=5))
+        assert cache.default_timeout == 300

--- a/tests/test_simple_cache.py
+++ b/tests/test_simple_cache.py
@@ -50,13 +50,13 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests, SerializerTests):
         threshold = 2 * len(self.sample_pairs) - 1
         cache = self.cache_factory(threshold=threshold)
         for k, v in self.sample_pairs.items():
-            assert cache.set(f"{k}-t0.1", v, timeout=0.1)
-            assert cache.set(f"{k}-t5.0", v, timeout=5.0)
+            assert cache.set(f"{k}-t1", v, timeout=1)
+            assert cache.set(f"{k}-t5", v, timeout=5)
         sleep(2)
         for k, v in self.sample_pairs.items():
             assert cache.set(k, v)
-            assert f"{k}-t5.0" in cache._cache.keys()
-            assert f"{k}-t0.1" not in cache._cache.keys()
+            assert f"{k}-t5" in cache._cache.keys()
+            assert f"{k}-t1" not in cache._cache.keys()
 
     def test_threshold_zero_defaults_to_500(self):
         """SimpleCache(threshold=0) should silently use 500, not 0."""
@@ -66,15 +66,15 @@ class TestSimpleCache(CommonTests, HasTests, ClearTests, SerializerTests):
     def test_add_on_expired_key_succeeds(self):
         """add() on a key whose TTL has elapsed should succeed."""
         cache = self.cache_factory()
-        cache.set("key", "original", timeout=0.1)
-        sleep(0.5)
+        cache.set("key", "original", timeout=1)
+        sleep(2)
         assert cache.add("key", "new") is True
         assert cache.get("key") == "new"
 
     def test_has_on_expired_key_returns_false(self):
         cache = self.cache_factory()
-        cache.set("key", "value", timeout=0.1)
-        sleep(0.5)
+        cache.set("key", "value", timeout=1)
+        sleep(2)
         assert cache.has("key") is False
 
     def test_delete_nonexistent_returns_false(self):


### PR DESCRIPTION
This is partly related to pallets-eco/flask-caching#266

I tried to implement this in flask-caching but it got out of hand when I tried to normalize the timeouts to ints in the proxy methods. Let me know what you think :-)
